### PR TITLE
CSS fixes for social media links in footer

### DIFF
--- a/client/src/layout/components/Footer.tsx
+++ b/client/src/layout/components/Footer.tsx
@@ -66,84 +66,80 @@ const Footer: FC = () => {
               <h2 className='mb-6 col-span-2 title-font uppercase font-semibold text-white text-xs'>
                 Social:
               </h2>
-              <div>
-                <ul className='text-gray-600 dark:text-gray-400 space-y-4'>
-                  <li>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.twitter}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      Twitter
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.discord}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      Discord
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.telegram}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      Telegram
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.github}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      Github
-                    </a>
-                  </li>
-                </ul>
-              </div>
-              <div>
-                <ul className='text-gray-600 dark:text-gray-400 space-y-4'>
-                  <li>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.medium}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      Medium
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.youtube}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      Youtube
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.linkedin}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      LinkedIn
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              <ul className='text-gray-600 dark:text-gray-400 space-y-4'>
+                <li>
+                  <a
+                    target='_blank'
+                    href={EXTERNAL_ROUTES.social.twitter}
+                    className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
+                    rel='noreferrer'
+                  >
+                    Twitter
+                  </a>
+                </li>
+                <li>
+                  <a
+                    target='_blank'
+                    href={EXTERNAL_ROUTES.social.discord}
+                    className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
+                    rel='noreferrer'
+                  >
+                    Discord
+                  </a>
+                </li>
+                <li>
+                  <a
+                    target='_blank'
+                    href={EXTERNAL_ROUTES.social.telegram}
+                    className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
+                    rel='noreferrer'
+                  >
+                    Telegram
+                  </a>
+                </li>
+                <li>
+                  <a
+                    target='_blank'
+                    href={EXTERNAL_ROUTES.social.github}
+                    className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
+                    rel='noreferrer'
+                  >
+                    Github
+                  </a>
+                </li>
+              </ul>
+              <ul className='text-gray-600 dark:text-gray-400 space-y-4'>
+                <li>
+                  <a
+                    target='_blank'
+                    href={EXTERNAL_ROUTES.social.medium}
+                    className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
+                    rel='noreferrer'
+                  >
+                    Medium
+                  </a>
+                </li>
+                <li>
+                  <a
+                    target='_blank'
+                    href={EXTERNAL_ROUTES.social.youtube}
+                    className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
+                    rel='noreferrer'
+                  >
+                    Youtube
+                  </a>
+                </li>
+                <li>
+                  <a
+                    target='_blank'
+                    href={EXTERNAL_ROUTES.social.linkedin}
+                    className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
+                    rel='noreferrer'
+                  >
+                    LinkedIn
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
         </div>

--- a/client/src/layout/components/Footer.tsx
+++ b/client/src/layout/components/Footer.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react'
 import dayjs from 'dayjs'
 import { Link } from 'react-router-dom'
+
+import type { FC } from 'react'
 
 // common
 import { EXTERNAL_ROUTES } from 'common/routes'
@@ -61,13 +62,13 @@ const Footer: FC = () => {
                 </li>
               </ul>
             </div>
-            <div className='grid grid-cols-2 gap-6'>
+            <div className='grid grid-cols-2 gap-x-6'>
+              <h2 className='mb-6 col-span-2 title-font uppercase font-semibold text-white text-xs'>
+                Social:
+              </h2>
               <div>
-                <h2 className='mb-6 title-font uppercase font-semibold text-white text-xs'>
-                  Social:
-                </h2>
-                <ul className='text-gray-600 dark:text-gray-400'>
-                  <li className='mb-4'>
+                <ul className='text-gray-600 dark:text-gray-400 space-y-4'>
+                  <li>
                     <a
                       target='_blank'
                       href={EXTERNAL_ROUTES.social.twitter}
@@ -77,7 +78,7 @@ const Footer: FC = () => {
                       Twitter
                     </a>
                   </li>
-                  <li className='mb-4'>
+                  <li>
                     <a
                       target='_blank'
                       href={EXTERNAL_ROUTES.social.discord}
@@ -87,7 +88,7 @@ const Footer: FC = () => {
                       Discord
                     </a>
                   </li>
-                  <li className='mb-4'>
+                  <li>
                     <a
                       target='_blank'
                       href={EXTERNAL_ROUTES.social.telegram}
@@ -110,18 +111,8 @@ const Footer: FC = () => {
                 </ul>
               </div>
               <div>
-                <ul className='text-gray-600 dark:text-gray-400 mt-11'>
-                  <li className='mb-4'>
-                    <a
-                      target='_blank'
-                      href={EXTERNAL_ROUTES.social.reddit}
-                      className='text-[#ffffffb3] text-xs hover:text-[#DE67E4]'
-                      rel='noreferrer'
-                    >
-                      Reddit
-                    </a>
-                  </li>
-                  <li className='mb-4'>
+                <ul className='text-gray-600 dark:text-gray-400 space-y-4'>
+                  <li>
                     <a
                       target='_blank'
                       href={EXTERNAL_ROUTES.social.medium}
@@ -131,7 +122,7 @@ const Footer: FC = () => {
                       Medium
                     </a>
                   </li>
-                  <li className='mb-4'>
+                  <li>
                     <a
                       target='_blank'
                       href={EXTERNAL_ROUTES.social.youtube}


### PR DESCRIPTION
Fixes issue #303

- Properly aligns the two columns of social links in the footer
- Removes the Reddit link because the forum is banned
- Confirmed per Natacha's comment that the header links fold into burger menu at smaller screen sizes