### PR TITLE
fix(space): pledge calc and update types

### DIFF
--- a/squid-blockexplorer/src/balances/storage.ts
+++ b/squid-blockexplorer/src/balances/storage.ts
@@ -44,7 +44,7 @@ export class BalanceStorage {
       return { free, reserved };
     }
     // TODO: consider converting account to Buffer within this func
-    const balance = await storage.asV2.get(accountId);
+    const balance = await storage.asV1.get(accountId);
     const { free, reserved } = balance.data;
     return { free, reserved };
   }
@@ -58,7 +58,7 @@ export class BalanceStorage {
       return { free, reserved };
     }
     // TODO: consider converting account to Buffer within this func
-    const balance = await storage.asV2.get(accountId);
+    const balance = await storage.asV1.get(accountId);
     const { free, reserved } = balance;
     return { free, reserved };
   }

--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -108,13 +108,13 @@ export function calcSpacePledged(solutionRange: bigint): bigint {
   const SIZE_OF_SOLUTION_RANGE = 8n;
   const SCALAR_FULL_BYTES = 32n;
 
-  const totalSpacePledged = BigInt(
+  const totalSpacePledged =
     MAX_U64 * PIECE_SIZE * SLOT_PROBABILITY[0]
     / RECORD_NUM_S_BUCKETS * RECORD_NUM_CHUNKS
     / solutionRange
     / SLOT_PROBABILITY[1]
     * SCALAR_FULL_BYTES
-    / SIZE_OF_SOLUTION_RANGE);
+    / SIZE_OF_SOLUTION_RANGE;
 
   return totalSpacePledged;
 }

--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -91,6 +91,7 @@ export function createCall(
   });
 }
 
+const PIECE_SIZE = 1048576n;
 
 /**
  * Calculates the space pledged by a solution range, based on monorepo calculation
@@ -100,7 +101,6 @@ export function createCall(
  */
 export function calcSpacePledged(solutionRange: bigint): bigint {
   const MAX_U64 = 2n ** 64n - 1n;
-  const PIECE_SIZE = 1048576n;
   const SLOT_PROBABILITY = [1n, 6n];
 
   const RECORD_NUM_S_BUCKETS = 65536n;
@@ -125,10 +125,10 @@ export function calcSpacePledged(solutionRange: bigint): bigint {
  * @return {bigint} - size of the history in bytes
  */
 export function calcHistorySize(segmentsCount: number): bigint {
-  const PIECES_IN_SEGMENT = 256;
-  const PIECE_SIZE = 1048576;
+  const PIECES_IN_SEGMENT = 256n;
+  const segmentsCountBigInt = BigInt(segmentsCount);
 
-  return BigInt(PIECE_SIZE * PIECES_IN_SEGMENT * segmentsCount);
+  return PIECE_SIZE * PIECES_IN_SEGMENT * segmentsCountBigInt;
 }
 
 /**

--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -91,8 +91,6 @@ export function createCall(
   });
 }
 
-const PIECE_SIZE = BigInt(1048576);
-const SLOT_PROBABILITY = [BigInt(1), BigInt(6)];
 
 /**
  * Calculates the space pledged by a solution range, based on monorepo calculation
@@ -101,22 +99,24 @@ const SLOT_PROBABILITY = [BigInt(1), BigInt(6)];
  * @return {bigint} - space pledged in bytes
  */
 export function calcSpacePledged(solutionRange: bigint): bigint {
-  const MAX_U64 = BigInt(2 ** 64 - 1);
+  const MAX_U64 = 2n ** 64n - 1n;
+  const PIECE_SIZE = 1048576n;
+  const SLOT_PROBABILITY = [1n, 6n];
 
-  const RECORD_NUM_S_BUCKETS = BigInt(65536);
-  const RECORD_NUM_CHUNKS = BigInt(32768);
-  const SIZE_OF_SOLUTION_RANGE = BigInt(8);
-  const SCALAR_FULL_BYTES = BigInt(32);
+  const RECORD_NUM_S_BUCKETS = 65536n;
+  const RECORD_NUM_CHUNKS = 32768n;
+  const SIZE_OF_SOLUTION_RANGE = 8n;
+  const SCALAR_FULL_BYTES = 32n;
 
-  const history_size =
+  const totalSpacePledged = BigInt(
     MAX_U64 * PIECE_SIZE * SLOT_PROBABILITY[0]
     / RECORD_NUM_S_BUCKETS * RECORD_NUM_CHUNKS
     / solutionRange
     / SLOT_PROBABILITY[1]
     * SCALAR_FULL_BYTES
-    / SIZE_OF_SOLUTION_RANGE;
+    / SIZE_OF_SOLUTION_RANGE);
 
-  return history_size;
+  return totalSpacePledged;
 }
 
 /*
@@ -125,10 +125,10 @@ export function calcSpacePledged(solutionRange: bigint): bigint {
  * @return {bigint} - size of the history in bytes
  */
 export function calcHistorySize(segmentsCount: number): bigint {
-  const segmentCountBigInt = BigInt(segmentsCount);
-  const PIECES_IN_SEGMENT = BigInt(256);
+  const PIECES_IN_SEGMENT = 256;
+  const PIECE_SIZE = 1048576;
 
-  return PIECE_SIZE * PIECES_IN_SEGMENT * segmentCountBigInt;
+  return BigInt(PIECE_SIZE * PIECES_IN_SEGMENT * segmentsCount);
 }
 
 /**

--- a/squid-blockexplorer/src/types/calls.ts
+++ b/squid-blockexplorer/src/types/calls.ts
@@ -17,21 +17,17 @@ export class BalancesForceSetBalanceCall {
     }
 
     /**
-     * Set the regular balance of a given account.
-     * 
-     * The dispatch origin for this call is `root`.
+     * See [`Pallet::force_set_balance`].
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getCallHash('Balances.force_set_balance') === 'd0f1dc28aeba8805f92a7e983d0fba2621912dc1665264dd9c38cd3c0c912737'
     }
 
     /**
-     * Set the regular balance of a given account.
-     * 
-     * The dispatch origin for this call is `root`.
+     * See [`Pallet::force_set_balance`].
      */
-    get asV2(): {who: v2.MultiAddress, newFree: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: v1.MultiAddress, newFree: bigint} {
+        assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
 }
@@ -50,22 +46,14 @@ export class BalancesForceTransferCall {
     }
 
     /**
-     * Exactly as `transfer`, except the origin must be root and the source account may be
-     * specified.
-     * ## Complexity
-     * - Same as transfer, but additional read and write because the source account is not
-     *   assumed to be in the overlay.
+     * See [`Pallet::force_transfer`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Balances.force_transfer') === 'e5944fbe8224a17fe49f9c1d1d01efaf87fb1778fd39618512af54c9ba6f9dff'
     }
 
     /**
-     * Exactly as `transfer`, except the origin must be root and the source account may be
-     * specified.
-     * ## Complexity
-     * - Same as transfer, but additional read and write because the source account is not
-     *   assumed to be in the overlay.
+     * See [`Pallet::force_transfer`].
      */
     get asV1(): {source: v1.MultiAddress, dest: v1.MultiAddress, value: bigint} {
         assert(this.isV1)
@@ -87,63 +75,16 @@ export class BalancesForceUnreserveCall {
     }
 
     /**
-     * Unreserve some balance from a user by force.
-     * 
-     * Can only be called by ROOT.
+     * See [`Pallet::force_unreserve`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Balances.force_unreserve') === '30bc48977e2a7ad3fc8ac014948ded50fc54886bad9a1f65b02bb64f27d8a6be'
     }
 
     /**
-     * Unreserve some balance from a user by force.
-     * 
-     * Can only be called by ROOT.
+     * See [`Pallet::force_unreserve`].
      */
     get asV1(): {who: v1.MultiAddress, amount: bigint} {
-        assert(this.isV1)
-        return this._chain.decodeCall(this.call)
-    }
-}
-
-export class BalancesSetBalanceCall {
-    private readonly _chain: Chain
-    private readonly call: Call
-
-    constructor(ctx: CallContext)
-    constructor(ctx: ChainContext, call: Call)
-    constructor(ctx: CallContext, call?: Call) {
-        call = call || ctx.call
-        assert(call.name === 'Balances.set_balance')
-        this._chain = ctx._chain
-        this.call = call
-    }
-
-    /**
-     * Set the balances of a given account.
-     * 
-     * This will alter `FreeBalance` and `ReservedBalance` in storage. it will
-     * also alter the total issuance of the system (`TotalIssuance`) appropriately.
-     * If the new free or reserved balance is below the existential deposit,
-     * it will reset the account nonce (`frame_system::AccountNonce`).
-     * 
-     * The dispatch origin for this call is `root`.
-     */
-    get isV1(): boolean {
-        return this._chain.getCallHash('Balances.set_balance') === 'beb82909d38c015bc075ff8b107e47a02f8772bf5cf681d6cd84ef685e448a8f'
-    }
-
-    /**
-     * Set the balances of a given account.
-     * 
-     * This will alter `FreeBalance` and `ReservedBalance` in storage. it will
-     * also alter the total issuance of the system (`TotalIssuance`) appropriately.
-     * If the new free or reserved balance is below the existential deposit,
-     * it will reset the account nonce (`frame_system::AccountNonce`).
-     * 
-     * The dispatch origin for this call is `root`.
-     */
-    get asV1(): {who: v1.MultiAddress, newFree: bigint, newReserved: bigint} {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
@@ -163,27 +104,17 @@ export class BalancesSetBalanceDeprecatedCall {
     }
 
     /**
-     * Set the regular balance of a given account; it also takes a reserved balance but this
-     * must be the same as the account's current reserved balance.
-     * 
-     * The dispatch origin for this call is `root`.
-     * 
-     * WARNING: This call is DEPRECATED! Use `force_set_balance` instead.
+     * See [`Pallet::set_balance_deprecated`].
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getCallHash('Balances.set_balance_deprecated') === 'cd8eaf83a985e64a94900c5c58bbc2bbd20e03f5d571cf6065020f1a4281ff19'
     }
 
     /**
-     * Set the regular balance of a given account; it also takes a reserved balance but this
-     * must be the same as the account's current reserved balance.
-     * 
-     * The dispatch origin for this call is `root`.
-     * 
-     * WARNING: This call is DEPRECATED! Use `force_set_balance` instead.
+     * See [`Pallet::set_balance_deprecated`].
      */
-    get asV2(): {who: v2.MultiAddress, newFree: bigint, oldReserved: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: v1.MultiAddress, newFree: bigint, oldReserved: bigint} {
+        assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
 }
@@ -202,56 +133,14 @@ export class BalancesTransferCall {
     }
 
     /**
-     * Transfer some liquid free balance to another account.
-     * 
-     * `transfer` will set the `FreeBalance` of the sender and receiver.
-     * If the sender's account is below the existential deposit as a result
-     * of the transfer, the account will be reaped.
-     * 
-     * The dispatch origin for this call must be `Signed` by the transactor.
-     * 
-     * ## Complexity
-     * - Dependent on arguments but not critical, given proper implementations for input config
-     *   types. See related functions below.
-     * - It contains a limited number of reads and writes internally and no complex
-     *   computation.
-     * 
-     * Related functions:
-     * 
-     *   - `ensure_can_withdraw` is always called internally but has a bounded complexity.
-     *   - Transferring balances to accounts that did not exist before will cause
-     *     `T::OnNewAccount::on_new_account` to be called.
-     *   - Removing enough funds from an account will trigger `T::DustRemoval::on_unbalanced`.
-     *   - `transfer_keep_alive` works the same way as `transfer`, but has an additional check
-     *     that the transfer will not kill the origin account.
+     * See [`Pallet::transfer`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Balances.transfer') === 'fc85bea9d0d171982f66e8a55667d58dc9a1612bcafe84309942bf47e23e3094'
     }
 
     /**
-     * Transfer some liquid free balance to another account.
-     * 
-     * `transfer` will set the `FreeBalance` of the sender and receiver.
-     * If the sender's account is below the existential deposit as a result
-     * of the transfer, the account will be reaped.
-     * 
-     * The dispatch origin for this call must be `Signed` by the transactor.
-     * 
-     * ## Complexity
-     * - Dependent on arguments but not critical, given proper implementations for input config
-     *   types. See related functions below.
-     * - It contains a limited number of reads and writes internally and no complex
-     *   computation.
-     * 
-     * Related functions:
-     * 
-     *   - `ensure_can_withdraw` is always called internally but has a bounded complexity.
-     *   - Transferring balances to accounts that did not exist before will cause
-     *     `T::OnNewAccount::on_new_account` to be called.
-     *   - Removing enough funds from an account will trigger `T::DustRemoval::on_unbalanced`.
-     *   - `transfer_keep_alive` works the same way as `transfer`, but has an additional check
-     *     that the transfer will not kill the origin account.
+     * See [`Pallet::transfer`].
      */
     get asV1(): {dest: v1.MultiAddress, value: bigint} {
         assert(this.isV1)
@@ -273,44 +162,14 @@ export class BalancesTransferAllCall {
     }
 
     /**
-     * Transfer the entire transferable balance from the caller account.
-     * 
-     * NOTE: This function only attempts to transfer _transferable_ balances. This means that
-     * any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be
-     * transferred by this function. To ensure that this function results in a killed account,
-     * you might need to prepare the account by removing any reference counters, storage
-     * deposits, etc...
-     * 
-     * The dispatch origin of this call must be Signed.
-     * 
-     * - `dest`: The recipient of the transfer.
-     * - `keep_alive`: A boolean to determine if the `transfer_all` operation should send all
-     *   of the funds the account has, causing the sender account to be killed (false), or
-     *   transfer everything except at least the existential deposit, which will guarantee to
-     *   keep the sender account alive (true). ## Complexity
-     * - O(1). Just like transfer, but reading the user's transferable balance first.
+     * See [`Pallet::transfer_all`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Balances.transfer_all') === '9c94c2ca9979f6551af6e123fb6b6ba14d026f862f9a023706f8f88c556b355f'
     }
 
     /**
-     * Transfer the entire transferable balance from the caller account.
-     * 
-     * NOTE: This function only attempts to transfer _transferable_ balances. This means that
-     * any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be
-     * transferred by this function. To ensure that this function results in a killed account,
-     * you might need to prepare the account by removing any reference counters, storage
-     * deposits, etc...
-     * 
-     * The dispatch origin of this call must be Signed.
-     * 
-     * - `dest`: The recipient of the transfer.
-     * - `keep_alive`: A boolean to determine if the `transfer_all` operation should send all
-     *   of the funds the account has, causing the sender account to be killed (false), or
-     *   transfer everything except at least the existential deposit, which will guarantee to
-     *   keep the sender account alive (true). ## Complexity
-     * - O(1). Just like transfer, but reading the user's transferable balance first.
+     * See [`Pallet::transfer_all`].
      */
     get asV1(): {dest: v1.MultiAddress, keepAlive: boolean} {
         assert(this.isV1)
@@ -332,29 +191,17 @@ export class BalancesTransferAllowDeathCall {
     }
 
     /**
-     * Transfer some liquid free balance to another account.
-     * 
-     * `transfer_allow_death` will set the `FreeBalance` of the sender and receiver.
-     * If the sender's account is below the existential deposit as a result
-     * of the transfer, the account will be reaped.
-     * 
-     * The dispatch origin for this call must be `Signed` by the transactor.
+     * See [`Pallet::transfer_allow_death`].
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getCallHash('Balances.transfer_allow_death') === 'fc85bea9d0d171982f66e8a55667d58dc9a1612bcafe84309942bf47e23e3094'
     }
 
     /**
-     * Transfer some liquid free balance to another account.
-     * 
-     * `transfer_allow_death` will set the `FreeBalance` of the sender and receiver.
-     * If the sender's account is below the existential deposit as a result
-     * of the transfer, the account will be reaped.
-     * 
-     * The dispatch origin for this call must be `Signed` by the transactor.
+     * See [`Pallet::transfer_allow_death`].
      */
-    get asV2(): {dest: v2.MultiAddress, value: bigint} {
-        assert(this.isV2)
+    get asV1(): {dest: v1.MultiAddress, value: bigint} {
+        assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
 }
@@ -373,24 +220,14 @@ export class BalancesTransferKeepAliveCall {
     }
 
     /**
-     * Same as the [`transfer`] call, but with a check that the transfer will not kill the
-     * origin account.
-     * 
-     * 99% of the time you want [`transfer`] instead.
-     * 
-     * [`transfer`]: struct.Pallet.html#method.transfer
+     * See [`Pallet::transfer_keep_alive`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Balances.transfer_keep_alive') === 'fc85bea9d0d171982f66e8a55667d58dc9a1612bcafe84309942bf47e23e3094'
     }
 
     /**
-     * Same as the [`transfer`] call, but with a check that the transfer will not kill the
-     * origin account.
-     * 
-     * 99% of the time you want [`transfer`] instead.
-     * 
-     * [`transfer`]: struct.Pallet.html#method.transfer
+     * See [`Pallet::transfer_keep_alive`].
      */
     get asV1(): {dest: v1.MultiAddress, value: bigint} {
         assert(this.isV1)
@@ -412,31 +249,206 @@ export class BalancesUpgradeAccountsCall {
     }
 
     /**
-     * Upgrade a specified account.
-     * 
-     * - `origin`: Must be `Signed`.
-     * - `who`: The account to be upgraded.
-     * 
-     * This will waive the transaction fee if at least all but 10% of the accounts needed to
-     * be upgraded. (We let some not have to be upgraded just in order to allow for the
-     * possibililty of churn).
+     * See [`Pallet::upgrade_accounts`].
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getCallHash('Balances.upgrade_accounts') === 'e074d5a93414f189b47fbb5d94c57b62cfb9e63808a3c94665eeb2cfe53be8df'
     }
 
     /**
-     * Upgrade a specified account.
-     * 
-     * - `origin`: Must be `Signed`.
-     * - `who`: The account to be upgraded.
-     * 
-     * This will waive the transaction fee if at least all but 10% of the accounts needed to
-     * be upgraded. (We let some not have to be upgraded just in order to allow for the
-     * possibililty of churn).
+     * See [`Pallet::upgrade_accounts`].
      */
-    get asV2(): {who: Uint8Array[]} {
+    get asV1(): {who: Uint8Array[]} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsAutoStakeBlockRewardsCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.auto_stake_block_rewards')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::auto_stake_block_rewards`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.auto_stake_block_rewards') === '8ffd479fbc1b33b18b9485df09465e8f37e733ec4184266f9bbe335de066f5ec'
+    }
+
+    /**
+     * See [`Pallet::auto_stake_block_rewards`].
+     */
+    get asV1(): {operatorId: bigint} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsDeregisterOperatorCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.deregister_operator')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::deregister_operator`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.deregister_operator') === '8ffd479fbc1b33b18b9485df09465e8f37e733ec4184266f9bbe335de066f5ec'
+    }
+
+    /**
+     * See [`Pallet::deregister_operator`].
+     */
+    get asV1(): {operatorId: bigint} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsInstantiateDomainCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.instantiate_domain')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::instantiate_domain`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.instantiate_domain') === 'f2fb2e1766adc302b2d1177f4ae0a100405f14e64416f638d3f0d432276852c5'
+    }
+
+    /**
+     * See [`Pallet::instantiate_domain`].
+     */
+    get asV1(): {domainConfig: v1.DomainConfig} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+
+    /**
+     * See [`Pallet::instantiate_domain`].
+     */
+    get isV2(): boolean {
+        return this._chain.getCallHash('Domains.instantiate_domain') === '9e6ec7bab2c44f72dcdb642b6157dc8e80a9227bce213879f3e7a906fedaa6c0'
+    }
+
+    /**
+     * See [`Pallet::instantiate_domain`].
+     */
+    get asV2(): {domainConfig: v2.DomainConfig, rawGenesis: Uint8Array} {
         assert(this.isV2)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsNominateOperatorCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.nominate_operator')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::nominate_operator`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.nominate_operator') === '421439c565b86b79d37b99791bc849f5eed06aea48fd8b3e0e7ebe6031d2f7f5'
+    }
+
+    /**
+     * See [`Pallet::nominate_operator`].
+     */
+    get asV1(): {operatorId: bigint, amount: bigint} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsRegisterDomainRuntimeCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.register_domain_runtime')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::register_domain_runtime`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.register_domain_runtime') === 'd724fc2d77a6cd5da8f35b0b6e4ddd2280e6273c54aa153159a00a6a5a205c4b'
+    }
+
+    /**
+     * See [`Pallet::register_domain_runtime`].
+     */
+    get asV1(): {runtimeName: Uint8Array, runtimeType: v1.RuntimeType, code: Uint8Array} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsRegisterOperatorCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.register_operator')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::register_operator`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.register_operator') === '893130193e63d991613dabb9eae4080125a976fe0ef7924d97334daee0c9ce08'
+    }
+
+    /**
+     * See [`Pallet::register_operator`].
+     */
+    get asV1(): {domainId: number, amount: bigint, config: v1.OperatorConfig} {
+        assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
 }
@@ -454,34 +466,17 @@ export class DomainsSubmitBundleCall {
         this.call = call
     }
 
+    /**
+     * See [`Pallet::submit_bundle`].
+     */
     get isV1(): boolean {
-        return this._chain.getCallHash('Domains.submit_bundle') === 'ea2fedb0a5a25cec8ff8e0d4b7e62c04790623a50700fc54bda63634058e00eb'
+        return this._chain.getCallHash('Domains.submit_bundle') === 'aef0f85b0417504063a7ead6e112823be185b5e82e204a4c505c9ad0773a031f'
     }
 
-    get asV1(): {signedOpaqueBundle: v1.SignedBundle} {
-        assert(this.isV1)
-        return this._chain.decodeCall(this.call)
-    }
-}
-
-export class DomainsSubmitBundleEquivocationProofCall {
-    private readonly _chain: Chain
-    private readonly call: Call
-
-    constructor(ctx: CallContext)
-    constructor(ctx: ChainContext, call: Call)
-    constructor(ctx: CallContext, call?: Call) {
-        call = call || ctx.call
-        assert(call.name === 'Domains.submit_bundle_equivocation_proof')
-        this._chain = ctx._chain
-        this.call = call
-    }
-
-    get isV1(): boolean {
-        return this._chain.getCallHash('Domains.submit_bundle_equivocation_proof') === '316184de034a98317cea298873e0307efa0534516f30eca23170ab2a66cae510'
-    }
-
-    get asV1(): {bundleEquivocationProof: v1.BundleEquivocationProof} {
+    /**
+     * See [`Pallet::submit_bundle`].
+     */
+    get asV1(): {opaqueBundle: v1.Bundle} {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
@@ -500,17 +495,23 @@ export class DomainsSubmitFraudProofCall {
         this.call = call
     }
 
+    /**
+     * See [`Pallet::submit_fraud_proof`].
+     */
     get isV1(): boolean {
-        return this._chain.getCallHash('Domains.submit_fraud_proof') === 'e3d8f8af0fc10273fcfbefcdba8ff76d67b055757a312521e34f33af75a0d532'
+        return this._chain.getCallHash('Domains.submit_fraud_proof') === '81d52e0c7de33d88398de6aab2c017e9e8719dece786d20238236c290af58eed'
     }
 
+    /**
+     * See [`Pallet::submit_fraud_proof`].
+     */
     get asV1(): {fraudProof: v1.FraudProof} {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
 }
 
-export class DomainsSubmitInvalidTransactionProofCall {
+export class DomainsSwitchDomainCall {
     private readonly _chain: Chain
     private readonly call: Call
 
@@ -518,16 +519,80 @@ export class DomainsSubmitInvalidTransactionProofCall {
     constructor(ctx: ChainContext, call: Call)
     constructor(ctx: CallContext, call?: Call) {
         call = call || ctx.call
-        assert(call.name === 'Domains.submit_invalid_transaction_proof')
+        assert(call.name === 'Domains.switch_domain')
         this._chain = ctx._chain
         this.call = call
     }
 
+    /**
+     * See [`Pallet::switch_domain`].
+     */
     get isV1(): boolean {
-        return this._chain.getCallHash('Domains.submit_invalid_transaction_proof') === '627394a5353077d72c8120df137b8421f4a4799b1c839e4df2e8fd351bde3671'
+        return this._chain.getCallHash('Domains.switch_domain') === '74d2d29b12e7f73697440e4c37b44221ef01aec8716b9c5f1bc8b95948c21642'
     }
 
-    get asV1(): {invalidTransactionProof: v1.InvalidTransactionProof} {
+    /**
+     * See [`Pallet::switch_domain`].
+     */
+    get asV1(): {operatorId: bigint, newDomainId: number} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsUpgradeDomainRuntimeCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.upgrade_domain_runtime')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::upgrade_domain_runtime`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.upgrade_domain_runtime') === '2286d8522d818ce5f2967ebc2741f0ed01ca58b9b87918dfa899c8799d2ed4c3'
+    }
+
+    /**
+     * See [`Pallet::upgrade_domain_runtime`].
+     */
+    get asV1(): {runtimeId: number, code: Uint8Array} {
+        assert(this.isV1)
+        return this._chain.decodeCall(this.call)
+    }
+}
+
+export class DomainsWithdrawStakeCall {
+    private readonly _chain: Chain
+    private readonly call: Call
+
+    constructor(ctx: CallContext)
+    constructor(ctx: ChainContext, call: Call)
+    constructor(ctx: CallContext, call?: Call) {
+        call = call || ctx.call
+        assert(call.name === 'Domains.withdraw_stake')
+        this._chain = ctx._chain
+        this.call = call
+    }
+
+    /**
+     * See [`Pallet::withdraw_stake`].
+     */
+    get isV1(): boolean {
+        return this._chain.getCallHash('Domains.withdraw_stake') === '79487a357f90f713eb5d2263a90cc8df0fbd35eb9b921e828114a1e85cc61c9d'
+    }
+
+    /**
+     * See [`Pallet::withdraw_stake`].
+     */
+    get asV1(): {operatorId: bigint, withdraw: v1.Withdraw} {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)
     }
@@ -547,14 +612,14 @@ export class FeedsCloseCall {
     }
 
     /**
-     * Closes the feed and stops accepting new feed.
+     * See [`Pallet::close`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Feeds.close') === '215745b2763961a0f0dd6ee97e822fbabd09557e006da37ed1d2d580fbb0e209'
     }
 
     /**
-     * Closes the feed and stops accepting new feed.
+     * See [`Pallet::close`].
      */
     get asV1(): {feedId: bigint} {
         assert(this.isV1)
@@ -576,14 +641,14 @@ export class FeedsCreateCall {
     }
 
     /**
-     * Create a new feed
+     * See [`Pallet::create`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Feeds.create') === '66c965d9a88f038143b233616e89f9c8ae80b322d24d4937d7d311ec2a2b6347'
     }
 
     /**
-     * Create a new feed
+     * See [`Pallet::create`].
      */
     get asV1(): {feedProcessorId: v1.FeedProcessorKind, initData: (Uint8Array | undefined)} {
         assert(this.isV1)
@@ -605,14 +670,14 @@ export class FeedsPutCall {
     }
 
     /**
-     * Put a new object into a feed
+     * See [`Pallet::put`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Feeds.put') === 'e38c212433ff4faa0fb098d7a66d9af9a81e760527a4fcbcef9f88e764e7a784'
     }
 
     /**
-     * Put a new object into a feed
+     * See [`Pallet::put`].
      */
     get asV1(): {feedId: bigint, object: Uint8Array} {
         assert(this.isV1)
@@ -634,14 +699,14 @@ export class FeedsTransferCall {
     }
 
     /**
-     * Transfers feed from current owner to new owner
+     * See [`Pallet::transfer`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Feeds.transfer') === '3328c86a3211eb2f91fc3a8d321503b5fa4fbafe3b37514cc70787fd332becb2'
     }
 
     /**
-     * Transfers feed from current owner to new owner
+     * See [`Pallet::transfer`].
      */
     get asV1(): {feedId: bigint, newOwner: v1.MultiAddress} {
         assert(this.isV1)
@@ -663,14 +728,14 @@ export class FeedsUpdateCall {
     }
 
     /**
-     * Updates the feed with init data provided.
+     * See [`Pallet::update`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Feeds.update') === '74416376cca34f04132f5d713868526654c3ce9bbe110edbfa9c70ece8bbd84e'
     }
 
     /**
-     * Updates the feed with init data provided.
+     * See [`Pallet::update`].
      */
     get asV1(): {feedId: bigint, feedProcessorId: v1.FeedProcessorKind, initData: (Uint8Array | undefined)} {
         assert(this.isV1)
@@ -692,14 +757,14 @@ export class ObjectStorePutCall {
     }
 
     /**
-     * Put a new object into a feed
+     * See [`Pallet::put`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('ObjectStore.put') === 'db1b3cc100eb94c9fc90e677c8e1837278395ece67b068bc0462ae353315387d'
     }
 
     /**
-     * Put a new object into a feed
+     * See [`Pallet::put`].
      */
     get asV1(): {object: Uint8Array} {
         assert(this.isV1)
@@ -721,14 +786,14 @@ export class SubspaceEnableAuthoringByAnyoneCall {
     }
 
     /**
-     * Enable storage access for all users.
+     * See [`Pallet::enable_authoring_by_anyone`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Subspace.enable_authoring_by_anyone') === '01f2f9c28aa1d4d36a81ff042620b6677d25bf07c2bf4acc37b58658778a4fca'
     }
 
     /**
-     * Enable storage access for all users.
+     * See [`Pallet::enable_authoring_by_anyone`].
      */
     get asV1(): null {
         assert(this.isV1)
@@ -750,14 +815,14 @@ export class SubspaceEnableRewardsCall {
     }
 
     /**
-     * Enable rewards for blocks and votes at specified block height.
+     * See [`Pallet::enable_rewards`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Subspace.enable_rewards') === '1bdaf75fb5be86cd00e96445c81877b4da02821f453e6b767650c5299dd02b65'
     }
 
     /**
-     * Enable rewards for blocks and votes at specified block height.
+     * See [`Pallet::enable_rewards`].
      */
     get asV1(): {height: (number | undefined)} {
         assert(this.isV1)
@@ -779,16 +844,14 @@ export class SubspaceEnableSolutionRangeAdjustmentCall {
     }
 
     /**
-     * Enable solution range adjustment after every era.
-     * Note: No effect on the solution range for the current era
+     * See [`Pallet::enable_solution_range_adjustment`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Subspace.enable_solution_range_adjustment') === 'b8131d894f8e6b026073d301af2b9294a27af5e9b08c38e806f1987577845094'
     }
 
     /**
-     * Enable solution range adjustment after every era.
-     * Note: No effect on the solution range for the current era
+     * See [`Pallet::enable_solution_range_adjustment`].
      */
     get asV1(): {solutionRangeOverride: (bigint | undefined), votingSolutionRangeOverride: (bigint | undefined)} {
         assert(this.isV1)
@@ -810,14 +873,14 @@ export class SubspaceEnableStorageAccessCall {
     }
 
     /**
-     * Enable storage access for all users.
+     * See [`Pallet::enable_storage_access`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Subspace.enable_storage_access') === '01f2f9c28aa1d4d36a81ff042620b6677d25bf07c2bf4acc37b58658778a4fca'
     }
 
     /**
-     * Enable storage access for all users.
+     * See [`Pallet::enable_storage_access`].
      */
     get asV1(): null {
         assert(this.isV1)
@@ -839,24 +902,14 @@ export class SubspaceReportEquivocationCall {
     }
 
     /**
-     * Report farmer equivocation/misbehavior. This method will verify the equivocation proof.
-     * If valid, the offence will be reported.
-     * 
-     * This extrinsic must be called unsigned and it is expected that only block authors will
-     * call it (validated in `ValidateUnsigned`), as such if the block author is defined it
-     * will be defined as the equivocation reporter.
+     * See [`Pallet::report_equivocation`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Subspace.report_equivocation') === '3b4dd8eb1272754b8223d410185edb75c6fa1763cb0899691848da9838d75c43'
     }
 
     /**
-     * Report farmer equivocation/misbehavior. This method will verify the equivocation proof.
-     * If valid, the offence will be reported.
-     * 
-     * This extrinsic must be called unsigned and it is expected that only block authors will
-     * call it (validated in `ValidateUnsigned`), as such if the block author is defined it
-     * will be defined as the equivocation reporter.
+     * See [`Pallet::report_equivocation`].
      */
     get asV1(): {equivocationProof: v1.EquivocationProof} {
         assert(this.isV1)
@@ -878,16 +931,14 @@ export class SubspaceStoreSegmentHeadersCall {
     }
 
     /**
-     * Submit new segment header to the blockchain. This is an inherent extrinsic and part of
-     * the Subspace consensus logic.
+     * See [`Pallet::store_segment_headers`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Subspace.store_segment_headers') === '59a81d6113b19526de1426393eb3f6f99fd5b1571272159f3399242e8ed6730d'
     }
 
     /**
-     * Submit new segment header to the blockchain. This is an inherent extrinsic and part of
-     * the Subspace consensus logic.
+     * See [`Pallet::store_segment_headers`].
      */
     get asV1(): {segmentHeaders: v1.SegmentHeader[]} {
         assert(this.isV1)
@@ -909,14 +960,14 @@ export class SubspaceVoteCall {
     }
 
     /**
-     * Farmer vote, currently only used for extra rewards to farmers.
+     * See [`Pallet::vote`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Subspace.vote') === '88d21a29d68a7b63d2c53bb731dd8407a0c3d56f3345e349cb8e27d32715b9a2'
+        return this._chain.getCallHash('Subspace.vote') === 'e557cbec9e62a4221a127615ed68970f8d78cd68d7f06408c5af21dff5cd0d97'
     }
 
     /**
-     * Farmer vote, currently only used for extra rewards to farmers.
+     * See [`Pallet::vote`].
      */
     get asV1(): {signedVote: v1.SignedVote} {
         assert(this.isV1)
@@ -938,26 +989,14 @@ export class SudoSetKeyCall {
     }
 
     /**
-     * Authenticates the current sudo key and sets the given AccountId (`new`) as the new sudo
-     * key.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::set_key`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Sudo.set_key') === 'e634aac3331d47a56ff572c52ad90a648769dfbf2c00d7bd44498b4ee41f6ac7'
     }
 
     /**
-     * Authenticates the current sudo key and sets the given AccountId (`new`) as the new sudo
-     * key.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::set_key`].
      */
     get asV1(): {new: v1.MultiAddress} {
         assert(this.isV1)
@@ -979,24 +1018,14 @@ export class SudoSudoCall {
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Sudo.sudo') === '666f9f5b584b495e6d225992b0dd326d44d763e775fe9d9b7dfe5a3f2b5c282e'
+        return this._chain.getCallHash('Sudo.sudo') === '290ebb9b9ee7cb9506ab3cabbcc6107dec8b403a1431e154f70963449c362592'
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo`].
      */
     get asV1(): {call: v1.Call} {
         assert(this.isV1)
@@ -1004,24 +1033,14 @@ export class SudoSudoCall {
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Sudo.sudo') === '096e794a96becc83c5eb398af15b22b5029ec1753aa94afe4e6497009e7d091a'
+        return this._chain.getCallHash('Sudo.sudo') === '021eb4ca3d0532cc62f6c3b37856e94bc2d24ad1fa5754c65c8a901d771c6495'
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo`].
      */
     get asV2(): {call: v2.Call} {
         assert(this.isV2)
@@ -1043,26 +1062,14 @@ export class SudoSudoAsCall {
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Signed` origin from
-     * a given account.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_as`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Sudo.sudo_as') === '5a975fed99eaaeba728aa16cd3e3a39f34c117a8328c977b2d47bfc30d22f8c2'
+        return this._chain.getCallHash('Sudo.sudo_as') === 'a6cd9bb26c4824f8372d0dd08c27c41f42b2da5526563a8a7af320700df29b25'
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Signed` origin from
-     * a given account.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_as`].
      */
     get asV1(): {who: v1.MultiAddress, call: v1.Call} {
         assert(this.isV1)
@@ -1070,26 +1077,14 @@ export class SudoSudoAsCall {
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Signed` origin from
-     * a given account.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_as`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Sudo.sudo_as') === 'd1ae94fda0f2adf34fe611ebe1db5ce79da3de68e4439947a79fde6673516463'
+        return this._chain.getCallHash('Sudo.sudo_as') === '8f85fae7a39d88ea5b800a8de3a45c60496ce7e62c322b3b47b0e62a9025cfb4'
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Signed` origin from
-     * a given account.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_as`].
      */
     get asV2(): {who: v2.MultiAddress, call: v2.Call} {
         assert(this.isV2)
@@ -1111,28 +1106,14 @@ export class SudoSudoUncheckedWeightCall {
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * This function does not check the weight of the call, and instead allows the
-     * Sudo user to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_unchecked_weight`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Sudo.sudo_unchecked_weight') === 'ce4dfdfb75585c424e03f412d317af8082d3b4b63e667f2acfc9c48b2f978398'
+        return this._chain.getCallHash('Sudo.sudo_unchecked_weight') === '4fdd386b71b0304e0018897b1e5253379503ed36ae1880a2b4142b17ea6a2bfd'
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * This function does not check the weight of the call, and instead allows the
-     * Sudo user to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_unchecked_weight`].
      */
     get asV1(): {call: v1.Call, weight: v1.Weight} {
         assert(this.isV1)
@@ -1140,28 +1121,14 @@ export class SudoSudoUncheckedWeightCall {
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * This function does not check the weight of the call, and instead allows the
-     * Sudo user to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_unchecked_weight`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Sudo.sudo_unchecked_weight') === 'c0eb62f6b986f92f1adced6e18f9d455b281d2c2e0b88a80fc159b87c1263c04'
+        return this._chain.getCallHash('Sudo.sudo_unchecked_weight') === 'b4dca4e1c97f2ece801f824c7075ae7595136d3657931968fd4186ae36009e07'
     }
 
     /**
-     * Authenticates the sudo key and dispatches a function call with `Root` origin.
-     * This function does not check the weight of the call, and instead allows the
-     * Sudo user to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Signed_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::sudo_unchecked_weight`].
      */
     get asV2(): {call: v2.Call, weight: v2.Weight} {
         assert(this.isV2)
@@ -1183,20 +1150,14 @@ export class SystemKillPrefixCall {
     }
 
     /**
-     * Kill all storage items with a key that starts with the given prefix.
-     * 
-     * **NOTE:** We rely on the Root origin to provide us the number of subkeys under
-     * the prefix we are removing to accurately calculate the weight of this function.
+     * See [`Pallet::kill_prefix`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.kill_prefix') === 'dfbadd42bee8b18fc81cf78683511061181cffbf7a8ebfd3e5719c389b373d93'
     }
 
     /**
-     * Kill all storage items with a key that starts with the given prefix.
-     * 
-     * **NOTE:** We rely on the Root origin to provide us the number of subkeys under
-     * the prefix we are removing to accurately calculate the weight of this function.
+     * See [`Pallet::kill_prefix`].
      */
     get asV1(): {prefix: Uint8Array, subkeys: number} {
         assert(this.isV1)
@@ -1218,14 +1179,14 @@ export class SystemKillStorageCall {
     }
 
     /**
-     * Kill some items from storage.
+     * See [`Pallet::kill_storage`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.kill_storage') === 'eac21dc14e927c003d9c634fb019d04128f71f8529d2914b10a56b85289c2c11'
     }
 
     /**
-     * Kill some items from storage.
+     * See [`Pallet::kill_storage`].
      */
     get asV1(): {keys: Uint8Array[]} {
         assert(this.isV1)
@@ -1247,20 +1208,14 @@ export class SystemRemarkCall {
     }
 
     /**
-     * Make some on-chain remark.
-     * 
-     * ## Complexity
-     * - `O(1)`
+     * See [`Pallet::remark`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.remark') === 'f4e9b5b7572eeae92978087ece9b4f57cb5cab4f16baf5625bb9ec4a432bad63'
     }
 
     /**
-     * Make some on-chain remark.
-     * 
-     * ## Complexity
-     * - `O(1)`
+     * See [`Pallet::remark`].
      */
     get asV1(): {remark: Uint8Array} {
         assert(this.isV1)
@@ -1282,14 +1237,14 @@ export class SystemRemarkWithEventCall {
     }
 
     /**
-     * Make some on-chain remark and emit event.
+     * See [`Pallet::remark_with_event`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.remark_with_event') === 'f4e9b5b7572eeae92978087ece9b4f57cb5cab4f16baf5625bb9ec4a432bad63'
     }
 
     /**
-     * Make some on-chain remark and emit event.
+     * See [`Pallet::remark_with_event`].
      */
     get asV1(): {remark: Uint8Array} {
         assert(this.isV1)
@@ -1311,20 +1266,14 @@ export class SystemSetCodeCall {
     }
 
     /**
-     * Set the new runtime code.
-     * 
-     * ## Complexity
-     * - `O(C + S)` where `C` length of `code` and `S` complexity of `can_set_code`
+     * See [`Pallet::set_code`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.set_code') === '7bf3d4785d9be7a4872f39cbd3702a66e16f7ee01e4446fb4a05624dc0ec4c93'
     }
 
     /**
-     * Set the new runtime code.
-     * 
-     * ## Complexity
-     * - `O(C + S)` where `C` length of `code` and `S` complexity of `can_set_code`
+     * See [`Pallet::set_code`].
      */
     get asV1(): {code: Uint8Array} {
         assert(this.isV1)
@@ -1346,20 +1295,14 @@ export class SystemSetCodeWithoutChecksCall {
     }
 
     /**
-     * Set the new runtime code without doing any checks of the given `code`.
-     * 
-     * ## Complexity
-     * - `O(C)` where `C` length of `code`
+     * See [`Pallet::set_code_without_checks`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.set_code_without_checks') === '7bf3d4785d9be7a4872f39cbd3702a66e16f7ee01e4446fb4a05624dc0ec4c93'
     }
 
     /**
-     * Set the new runtime code without doing any checks of the given `code`.
-     * 
-     * ## Complexity
-     * - `O(C)` where `C` length of `code`
+     * See [`Pallet::set_code_without_checks`].
      */
     get asV1(): {code: Uint8Array} {
         assert(this.isV1)
@@ -1381,14 +1324,14 @@ export class SystemSetHeapPagesCall {
     }
 
     /**
-     * Set the number of pages in the WebAssembly environment's heap.
+     * See [`Pallet::set_heap_pages`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.set_heap_pages') === '130172e47c5e517627712b4d084768b98489d920284223ea8ef9c462339b5808'
     }
 
     /**
-     * Set the number of pages in the WebAssembly environment's heap.
+     * See [`Pallet::set_heap_pages`].
      */
     get asV1(): {pages: bigint} {
         assert(this.isV1)
@@ -1410,14 +1353,14 @@ export class SystemSetStorageCall {
     }
 
     /**
-     * Set some items of storage.
+     * See [`Pallet::set_storage`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('System.set_storage') === 'a4fb507615d69849afb1b2ee654006f9be48bb6e960a4674624d6e46e4382083'
     }
 
     /**
-     * Set some items of storage.
+     * See [`Pallet::set_storage`].
      */
     get asV1(): {items: [Uint8Array, Uint8Array][]} {
         assert(this.isV1)
@@ -1439,42 +1382,14 @@ export class TimestampSetCall {
     }
 
     /**
-     * Set the current time.
-     * 
-     * This call should be invoked exactly once per block. It will panic at the finalization
-     * phase, if this call hasn't been invoked by that time.
-     * 
-     * The timestamp should be greater than the previous one by the amount specified by
-     * `MinimumPeriod`.
-     * 
-     * The dispatch origin for this call must be `Inherent`.
-     * 
-     * ## Complexity
-     * - `O(1)` (Note that implementations of `OnTimestampSet` must also be `O(1)`)
-     * - 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in
-     *   `on_finalize`)
-     * - 1 event handler `on_timestamp_set`. Must be `O(1)`.
+     * See [`Pallet::set`].
      */
     get isV1(): boolean {
         return this._chain.getCallHash('Timestamp.set') === '6a8b8ba2be107f0853b674eec0026cc440b314db44d0e2c59b36e353355aed14'
     }
 
     /**
-     * Set the current time.
-     * 
-     * This call should be invoked exactly once per block. It will panic at the finalization
-     * phase, if this call hasn't been invoked by that time.
-     * 
-     * The timestamp should be greater than the previous one by the amount specified by
-     * `MinimumPeriod`.
-     * 
-     * The dispatch origin for this call must be `Inherent`.
-     * 
-     * ## Complexity
-     * - `O(1)` (Note that implementations of `OnTimestampSet` must also be `O(1)`)
-     * - 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in
-     *   `on_finalize`)
-     * - 1 event handler `on_timestamp_set`. Must be `O(1)`.
+     * See [`Pallet::set`].
      */
     get asV1(): {now: bigint} {
         assert(this.isV1)
@@ -1496,38 +1411,14 @@ export class UtilityAsDerivativeCall {
     }
 
     /**
-     * Send a call through an indexed pseudonym of the sender.
-     * 
-     * Filter from origin are passed along. The call will be dispatched with an origin which
-     * use the same filter as the origin of this call.
-     * 
-     * NOTE: If you need to ensure that any account-based filtering is not honored (i.e.
-     * because you expect `proxy` to have been used prior in the call stack and you do not want
-     * the call restrictions to apply to any sub-accounts), then use `as_multi_threshold_1`
-     * in the Multisig pallet instead.
-     * 
-     * NOTE: Prior to version *12, this was called `as_limited_sub`.
-     * 
-     * The dispatch origin for this call must be _Signed_.
+     * See [`Pallet::as_derivative`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Utility.as_derivative') === 'b77bf2717807125e208aa04bf498a553586268a7b817197c1d1c704df331967b'
+        return this._chain.getCallHash('Utility.as_derivative') === 'bbd1ab9eaf3ce7f5b23d83cccc0f5e89ce56d519950bfa4542ef477a81c8bdbf'
     }
 
     /**
-     * Send a call through an indexed pseudonym of the sender.
-     * 
-     * Filter from origin are passed along. The call will be dispatched with an origin which
-     * use the same filter as the origin of this call.
-     * 
-     * NOTE: If you need to ensure that any account-based filtering is not honored (i.e.
-     * because you expect `proxy` to have been used prior in the call stack and you do not want
-     * the call restrictions to apply to any sub-accounts), then use `as_multi_threshold_1`
-     * in the Multisig pallet instead.
-     * 
-     * NOTE: Prior to version *12, this was called `as_limited_sub`.
-     * 
-     * The dispatch origin for this call must be _Signed_.
+     * See [`Pallet::as_derivative`].
      */
     get asV1(): {index: number, call: v1.Call} {
         assert(this.isV1)
@@ -1535,38 +1426,14 @@ export class UtilityAsDerivativeCall {
     }
 
     /**
-     * Send a call through an indexed pseudonym of the sender.
-     * 
-     * Filter from origin are passed along. The call will be dispatched with an origin which
-     * use the same filter as the origin of this call.
-     * 
-     * NOTE: If you need to ensure that any account-based filtering is not honored (i.e.
-     * because you expect `proxy` to have been used prior in the call stack and you do not want
-     * the call restrictions to apply to any sub-accounts), then use `as_multi_threshold_1`
-     * in the Multisig pallet instead.
-     * 
-     * NOTE: Prior to version *12, this was called `as_limited_sub`.
-     * 
-     * The dispatch origin for this call must be _Signed_.
+     * See [`Pallet::as_derivative`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Utility.as_derivative') === '33fa3bf2d7705a5772cd8409f3fc32eae1db5e0896e5ef30ebbb5da23ca02a92'
+        return this._chain.getCallHash('Utility.as_derivative') === 'a462d7f1cb03d449c0a9fc04912723638cac57b370fbe4d4a71a0b25dc51bd01'
     }
 
     /**
-     * Send a call through an indexed pseudonym of the sender.
-     * 
-     * Filter from origin are passed along. The call will be dispatched with an origin which
-     * use the same filter as the origin of this call.
-     * 
-     * NOTE: If you need to ensure that any account-based filtering is not honored (i.e.
-     * because you expect `proxy` to have been used prior in the call stack and you do not want
-     * the call restrictions to apply to any sub-accounts), then use `as_multi_threshold_1`
-     * in the Multisig pallet instead.
-     * 
-     * NOTE: Prior to version *12, this was called `as_limited_sub`.
-     * 
-     * The dispatch origin for this call must be _Signed_.
+     * See [`Pallet::as_derivative`].
      */
     get asV2(): {index: number, call: v2.Call} {
         assert(this.isV2)
@@ -1588,48 +1455,14 @@ export class UtilityBatchCall {
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
-     * 
-     * This will return `Ok` in all circumstances. To determine the success of the batch, an
-     * event is deposited. If a call failed and the batch was interrupted, then the
-     * `BatchInterrupted` event is deposited, along with the number of successful calls made
-     * and the error of the failed call. If all were successful, then the `BatchCompleted`
-     * event is deposited.
+     * See [`Pallet::batch`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Utility.batch') === 'bf9838347e06912b066bbbf7d80f874a2fa9b02920ef64b74480822f0a516cac'
+        return this._chain.getCallHash('Utility.batch') === '8f3ee40845b5299396e8404058d8c44d38df945134f46a9d8c6eed037a1e1ff1'
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
-     * 
-     * This will return `Ok` in all circumstances. To determine the success of the batch, an
-     * event is deposited. If a call failed and the batch was interrupted, then the
-     * `BatchInterrupted` event is deposited, along with the number of successful calls made
-     * and the error of the failed call. If all were successful, then the `BatchCompleted`
-     * event is deposited.
+     * See [`Pallet::batch`].
      */
     get asV1(): {calls: v1.Call[]} {
         assert(this.isV1)
@@ -1637,48 +1470,14 @@ export class UtilityBatchCall {
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
-     * 
-     * This will return `Ok` in all circumstances. To determine the success of the batch, an
-     * event is deposited. If a call failed and the batch was interrupted, then the
-     * `BatchInterrupted` event is deposited, along with the number of successful calls made
-     * and the error of the failed call. If all were successful, then the `BatchCompleted`
-     * event is deposited.
+     * See [`Pallet::batch`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Utility.batch') === 'c3fa4a3007084b1a44f4c14710af2dcbeac8f561f8cfcc1a5a4eb6452afce18e'
+        return this._chain.getCallHash('Utility.batch') === 'e7824a8166f28e08d9929c73f34b81e35a6e4df30c6bfa21e170295d48761b3e'
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
-     * 
-     * This will return `Ok` in all circumstances. To determine the success of the batch, an
-     * event is deposited. If a call failed and the batch was interrupted, then the
-     * `BatchInterrupted` event is deposited, along with the number of successful calls made
-     * and the error of the failed call. If all were successful, then the `BatchCompleted`
-     * event is deposited.
+     * See [`Pallet::batch`].
      */
     get asV2(): {calls: v2.Call[]} {
         assert(this.isV2)
@@ -1700,38 +1499,14 @@ export class UtilityBatchAllCall {
     }
 
     /**
-     * Send a batch of dispatch calls and atomically execute them.
-     * The whole transaction will rollback and fail if any of the calls failed.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::batch_all`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Utility.batch_all') === 'bf9838347e06912b066bbbf7d80f874a2fa9b02920ef64b74480822f0a516cac'
+        return this._chain.getCallHash('Utility.batch_all') === '8f3ee40845b5299396e8404058d8c44d38df945134f46a9d8c6eed037a1e1ff1'
     }
 
     /**
-     * Send a batch of dispatch calls and atomically execute them.
-     * The whole transaction will rollback and fail if any of the calls failed.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::batch_all`].
      */
     get asV1(): {calls: v1.Call[]} {
         assert(this.isV1)
@@ -1739,38 +1514,14 @@ export class UtilityBatchAllCall {
     }
 
     /**
-     * Send a batch of dispatch calls and atomically execute them.
-     * The whole transaction will rollback and fail if any of the calls failed.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::batch_all`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Utility.batch_all') === 'c3fa4a3007084b1a44f4c14710af2dcbeac8f561f8cfcc1a5a4eb6452afce18e'
+        return this._chain.getCallHash('Utility.batch_all') === 'e7824a8166f28e08d9929c73f34b81e35a6e4df30c6bfa21e170295d48761b3e'
     }
 
     /**
-     * Send a batch of dispatch calls and atomically execute them.
-     * The whole transaction will rollback and fail if any of the calls failed.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatched without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::batch_all`].
      */
     get asV2(): {calls: v2.Call[]} {
         assert(this.isV2)
@@ -1792,24 +1543,14 @@ export class UtilityDispatchAsCall {
     }
 
     /**
-     * Dispatches a function call with a provided origin.
-     * 
-     * The dispatch origin for this call must be _Root_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::dispatch_as`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Utility.dispatch_as') === 'b27b29b10641bb2bb13b75e10a2992a8999157ecc69f752774c370dfd73add86'
+        return this._chain.getCallHash('Utility.dispatch_as') === 'a1579f2a13e29309e7bdbd9082dc5b99bb7eb54b81e70334cee71bd9115adae7'
     }
 
     /**
-     * Dispatches a function call with a provided origin.
-     * 
-     * The dispatch origin for this call must be _Root_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::dispatch_as`].
      */
     get asV1(): {asOrigin: v1.OriginCaller, call: v1.Call} {
         assert(this.isV1)
@@ -1817,24 +1558,14 @@ export class UtilityDispatchAsCall {
     }
 
     /**
-     * Dispatches a function call with a provided origin.
-     * 
-     * The dispatch origin for this call must be _Root_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::dispatch_as`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Utility.dispatch_as') === '59ce3af6c1d6fe2899188574fccea1f1fa7f95a4ea97c1e1320c86cc645b2888'
+        return this._chain.getCallHash('Utility.dispatch_as') === '90b9ef03a1a91d62b1d46aeb52e09e2e226dd1d2761e623741ac61df4b16cd19'
     }
 
     /**
-     * Dispatches a function call with a provided origin.
-     * 
-     * The dispatch origin for this call must be _Root_.
-     * 
-     * ## Complexity
-     * - O(1).
+     * See [`Pallet::dispatch_as`].
      */
     get asV2(): {asOrigin: v2.OriginCaller, call: v2.Call} {
         assert(this.isV2)
@@ -1856,38 +1587,14 @@ export class UtilityForceBatchCall {
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * Unlike `batch`, it allows errors and won't interrupt.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatch without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::force_batch`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Utility.force_batch') === 'bf9838347e06912b066bbbf7d80f874a2fa9b02920ef64b74480822f0a516cac'
+        return this._chain.getCallHash('Utility.force_batch') === '8f3ee40845b5299396e8404058d8c44d38df945134f46a9d8c6eed037a1e1ff1'
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * Unlike `batch`, it allows errors and won't interrupt.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatch without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::force_batch`].
      */
     get asV1(): {calls: v1.Call[]} {
         assert(this.isV1)
@@ -1895,38 +1602,14 @@ export class UtilityForceBatchCall {
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * Unlike `batch`, it allows errors and won't interrupt.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatch without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::force_batch`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Utility.force_batch') === 'c3fa4a3007084b1a44f4c14710af2dcbeac8f561f8cfcc1a5a4eb6452afce18e'
+        return this._chain.getCallHash('Utility.force_batch') === 'e7824a8166f28e08d9929c73f34b81e35a6e4df30c6bfa21e170295d48761b3e'
     }
 
     /**
-     * Send a batch of dispatch calls.
-     * Unlike `batch`, it allows errors and won't interrupt.
-     * 
-     * May be called from any origin except `None`.
-     * 
-     * - `calls`: The calls to be dispatched from the same origin. The number of call must not
-     *   exceed the constant: `batched_calls_limit` (available in constant metadata).
-     * 
-     * If origin is root then the calls are dispatch without checking origin filter. (This
-     * includes bypassing `frame_system::Config::BaseCallFilter`).
-     * 
-     * ## Complexity
-     * - O(C) where C is the number of calls to be batched.
+     * See [`Pallet::force_batch`].
      */
     get asV2(): {calls: v2.Call[]} {
         assert(this.isV2)
@@ -1948,24 +1631,14 @@ export class UtilityWithWeightCall {
     }
 
     /**
-     * Dispatch a function call with a specified weight.
-     * 
-     * This function does not check the weight of the call, and instead allows the
-     * Root origin to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Root_.
+     * See [`Pallet::with_weight`].
      */
     get isV1(): boolean {
-        return this._chain.getCallHash('Utility.with_weight') === 'ce4dfdfb75585c424e03f412d317af8082d3b4b63e667f2acfc9c48b2f978398'
+        return this._chain.getCallHash('Utility.with_weight') === '4fdd386b71b0304e0018897b1e5253379503ed36ae1880a2b4142b17ea6a2bfd'
     }
 
     /**
-     * Dispatch a function call with a specified weight.
-     * 
-     * This function does not check the weight of the call, and instead allows the
-     * Root origin to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Root_.
+     * See [`Pallet::with_weight`].
      */
     get asV1(): {call: v1.Call, weight: v1.Weight} {
         assert(this.isV1)
@@ -1973,24 +1646,14 @@ export class UtilityWithWeightCall {
     }
 
     /**
-     * Dispatch a function call with a specified weight.
-     * 
-     * This function does not check the weight of the call, and instead allows the
-     * Root origin to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Root_.
+     * See [`Pallet::with_weight`].
      */
     get isV2(): boolean {
-        return this._chain.getCallHash('Utility.with_weight') === 'c0eb62f6b986f92f1adced6e18f9d455b281d2c2e0b88a80fc159b87c1263c04'
+        return this._chain.getCallHash('Utility.with_weight') === 'b4dca4e1c97f2ece801f824c7075ae7595136d3657931968fd4186ae36009e07'
     }
 
     /**
-     * Dispatch a function call with a specified weight.
-     * 
-     * This function does not check the weight of the call, and instead allows the
-     * Root origin to specify the weight of the call.
-     * 
-     * The dispatch origin for this call must be _Root_.
+     * See [`Pallet::with_weight`].
      */
     get asV2(): {call: v2.Call, weight: v2.Weight} {
         assert(this.isV2)
@@ -2011,10 +1674,16 @@ export class VestingClaimCall {
         this.call = call
     }
 
+    /**
+     * See [`Pallet::claim`].
+     */
     get isV1(): boolean {
         return this._chain.getCallHash('Vesting.claim') === '01f2f9c28aa1d4d36a81ff042620b6677d25bf07c2bf4acc37b58658778a4fca'
     }
 
+    /**
+     * See [`Pallet::claim`].
+     */
     get asV1(): null {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)
@@ -2034,10 +1703,16 @@ export class VestingClaimForCall {
         this.call = call
     }
 
+    /**
+     * See [`Pallet::claim_for`].
+     */
     get isV1(): boolean {
         return this._chain.getCallHash('Vesting.claim_for') === 'b1b9d2bb9f2a27d3dfcb795f19a6625638978d1474d5d4dd34d918f46415e1e9'
     }
 
+    /**
+     * See [`Pallet::claim_for`].
+     */
     get asV1(): {dest: v1.MultiAddress} {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)
@@ -2057,10 +1732,16 @@ export class VestingUpdateVestingSchedulesCall {
         this.call = call
     }
 
+    /**
+     * See [`Pallet::update_vesting_schedules`].
+     */
     get isV1(): boolean {
         return this._chain.getCallHash('Vesting.update_vesting_schedules') === '5cf5b6a09a9387300d4c3c69374c4045d3ca2a2794fa169a86fec9d8e1f3920c'
     }
 
+    /**
+     * See [`Pallet::update_vesting_schedules`].
+     */
     get asV1(): {who: v1.MultiAddress, vestingSchedules: v1.VestingSchedule[]} {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)
@@ -2080,10 +1761,16 @@ export class VestingVestedTransferCall {
         this.call = call
     }
 
+    /**
+     * See [`Pallet::vested_transfer`].
+     */
     get isV1(): boolean {
         return this._chain.getCallHash('Vesting.vested_transfer') === 'f1e312a24c806adf72eb68877c2620386cbfc53664014b14338b9491e044cb0d'
     }
 
+    /**
+     * See [`Pallet::vested_transfer`].
+     */
     get asV1(): {dest: v1.MultiAddress, schedule: v1.VestingSchedule} {
         assert(this.isV1)
         return this._chain.decodeCall(this.call)

--- a/squid-blockexplorer/src/types/constants.ts
+++ b/squid-blockexplorer/src/types/constants.ts
@@ -10,14 +10,28 @@ export class BalancesExistentialDepositConstant {
     }
 
     /**
-     *  The minimum amount required to keep an account open.
+     *  The minimum amount required to keep an account open. MUST BE GREATER THAN ZERO!
+     * 
+     *  If you *really* need it to be zero, you can enable the feature `insecure_zero_ed` for
+     *  this pallet. However, you do so at your own risk: this will open up a major DoS vector.
+     *  In case you have multiple sources of provider references, you may also get unexpected
+     *  behaviour if you set this to zero.
+     * 
+     *  Bottom line: Do yourself a favour and make it at least one!
      */
     get isV1() {
         return this._chain.getConstantTypeHash('Balances', 'ExistentialDeposit') === 'a73c503ad07b8dce07ffc3646a2c7aeacb1280015e3b79887f6a9b11dae120f1'
     }
 
     /**
-     *  The minimum amount required to keep an account open.
+     *  The minimum amount required to keep an account open. MUST BE GREATER THAN ZERO!
+     * 
+     *  If you *really* need it to be zero, you can enable the feature `insecure_zero_ed` for
+     *  this pallet. However, you do so at your own risk: this will open up a major DoS vector.
+     *  In case you have multiple sources of provider references, you may also get unexpected
+     *  behaviour if you set this to zero.
+     * 
+     *  Bottom line: Do yourself a favour and make it at least one!
      */
     get asV1(): bigint {
         assert(this.isV1)
@@ -42,15 +56,15 @@ export class BalancesMaxFreezesConstant {
     /**
      *  The maximum number of individual freeze locks that can exist on an account at any time.
      */
-    get isV2() {
+    get isV1() {
         return this._chain.getConstantTypeHash('Balances', 'MaxFreezes') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
     }
 
     /**
      *  The maximum number of individual freeze locks that can exist on an account at any time.
      */
-    get asV2(): number {
-        assert(this.isV2)
+    get asV1(): number {
+        assert(this.isV1)
         return this._chain.getConstant('Balances', 'MaxFreezes')
     }
 
@@ -72,15 +86,15 @@ export class BalancesMaxHoldsConstant {
     /**
      *  The maximum number of holds that can exist on an account at any time.
      */
-    get isV2() {
+    get isV1() {
         return this._chain.getConstantTypeHash('Balances', 'MaxHolds') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
     }
 
     /**
      *  The maximum number of holds that can exist on an account at any time.
      */
-    get asV2(): number {
-        assert(this.isV2)
+    get asV1(): number {
+        assert(this.isV1)
         return this._chain.getConstant('Balances', 'MaxHolds')
     }
 
@@ -154,6 +168,524 @@ export class BalancesMaxReservesConstant {
     }
 }
 
+export class DomainsBlockTreePruningDepthConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  The block tree pruning depth, its value should <= `BlockHashCount` because we
+     *  need the consensus block hash to verify execution receipt, which is used to
+     *  construct the node of the block tree.
+     * 
+     *  TODO: `BlockTreePruningDepth` <= `BlockHashCount` is not enough to guarantee the consensus block
+     *  hash must exists while verifying receipt because the domain block is not mapping to the consensus
+     *  block one by one, we need to either store the consensus block hash in runtime manually or store
+     *  the consensus block hash in the client side and use host function to get them in runtime.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'BlockTreePruningDepth') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  The block tree pruning depth, its value should <= `BlockHashCount` because we
+     *  need the consensus block hash to verify execution receipt, which is used to
+     *  construct the node of the block tree.
+     * 
+     *  TODO: `BlockTreePruningDepth` <= `BlockHashCount` is not enough to guarantee the consensus block
+     *  hash must exists while verifying receipt because the domain block is not mapping to the consensus
+     *  block one by one, we need to either store the consensus block hash in runtime manually or store
+     *  the consensus block hash in the client side and use host function to get them in runtime.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'BlockTreePruningDepth')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'BlockTreePruningDepth') != null
+    }
+}
+
+export class DomainsConfirmationDepthKConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Same with `pallet_subspace::Config::ConfirmationDepthK`.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'ConfirmationDepthK') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  Same with `pallet_subspace::Config::ConfirmationDepthK`.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'ConfirmationDepthK')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'ConfirmationDepthK') != null
+    }
+}
+
+export class DomainsDomainBlockRewardConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  A fixed domain block reward.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'DomainBlockReward') === 'a73c503ad07b8dce07ffc3646a2c7aeacb1280015e3b79887f6a9b11dae120f1'
+    }
+
+    /**
+     *  A fixed domain block reward.
+     */
+    get asV1(): bigint {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'DomainBlockReward')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'DomainBlockReward') != null
+    }
+}
+
+export class DomainsDomainInstantiationDepositConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  The amount of fund to be locked up for the domain instance creator.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'DomainInstantiationDeposit') === 'a73c503ad07b8dce07ffc3646a2c7aeacb1280015e3b79887f6a9b11dae120f1'
+    }
+
+    /**
+     *  The amount of fund to be locked up for the domain instance creator.
+     */
+    get asV1(): bigint {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'DomainInstantiationDeposit')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'DomainInstantiationDeposit') != null
+    }
+}
+
+export class DomainsDomainRuntimeUpgradeDelayConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Delay before a domain runtime is upgraded.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'DomainRuntimeUpgradeDelay') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  Delay before a domain runtime is upgraded.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'DomainRuntimeUpgradeDelay')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'DomainRuntimeUpgradeDelay') != null
+    }
+}
+
+export class DomainsDomainTxRangeAdjustmentIntervalConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Domain tx range is adjusted after every DomainTxRangeAdjustmentInterval blocks.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'DomainTxRangeAdjustmentInterval') === '2e8052d0ae8d237ad263438f986208df52f4f0e9f529557036c3b179dfb42f21'
+    }
+
+    /**
+     *  Domain tx range is adjusted after every DomainTxRangeAdjustmentInterval blocks.
+     */
+    get asV1(): bigint {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'DomainTxRangeAdjustmentInterval')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'DomainTxRangeAdjustmentInterval') != null
+    }
+}
+
+export class DomainsInitialDomainTxRangeConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Initial domain tx range value.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'InitialDomainTxRange') === '2e8052d0ae8d237ad263438f986208df52f4f0e9f529557036c3b179dfb42f21'
+    }
+
+    /**
+     *  Initial domain tx range value.
+     */
+    get asV1(): bigint {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'InitialDomainTxRange')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'InitialDomainTxRange') != null
+    }
+}
+
+export class DomainsMaxBundlesPerBlockConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  The maximum bundle per block limit for all domain.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'MaxBundlesPerBlock') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  The maximum bundle per block limit for all domain.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'MaxBundlesPerBlock')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'MaxBundlesPerBlock') != null
+    }
+}
+
+export class DomainsMaxDomainBlockSizeConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  The maximum block size limit for all domain.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'MaxDomainBlockSize') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  The maximum block size limit for all domain.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'MaxDomainBlockSize')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'MaxDomainBlockSize') != null
+    }
+}
+
+export class DomainsMaxDomainBlockWeightConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  The maximum block weight limit for all domain.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'MaxDomainBlockWeight') === 'c92b1d8d51239cdf34de2cc7cfa9141c62b02aaf420c1b8dfaf8d16d158d95b5'
+    }
+
+    /**
+     *  The maximum block weight limit for all domain.
+     */
+    get asV1(): v1.Weight {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'MaxDomainBlockWeight')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'MaxDomainBlockWeight') != null
+    }
+}
+
+export class DomainsMaxDomainNameLengthConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  The maximum domain name length limit for all domain.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'MaxDomainNameLength') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  The maximum domain name length limit for all domain.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'MaxDomainNameLength')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'MaxDomainNameLength') != null
+    }
+}
+
+export class DomainsMaxPendingStakingOperationConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  The maximum number of pending staking operation that can perform upon epoch transition.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'MaxPendingStakingOperation') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  The maximum number of pending staking operation that can perform upon epoch transition.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'MaxPendingStakingOperation')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'MaxPendingStakingOperation') != null
+    }
+}
+
+export class DomainsMinOperatorStakeConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Minimum operator stake required to become operator of a domain.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'MinOperatorStake') === 'a73c503ad07b8dce07ffc3646a2c7aeacb1280015e3b79887f6a9b11dae120f1'
+    }
+
+    /**
+     *  Minimum operator stake required to become operator of a domain.
+     */
+    get asV1(): bigint {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'MinOperatorStake')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'MinOperatorStake') != null
+    }
+}
+
+export class DomainsStakeEpochDurationConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Domain epoch transition interval
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'StakeEpochDuration') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  Domain epoch transition interval
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'StakeEpochDuration')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'StakeEpochDuration') != null
+    }
+}
+
+export class DomainsStakeWithdrawalLockingPeriodConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Minimum number of blocks after which any finalized withdrawals are released to nominators.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'StakeWithdrawalLockingPeriod') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
+    }
+
+    /**
+     *  Minimum number of blocks after which any finalized withdrawals are released to nominators.
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'StakeWithdrawalLockingPeriod')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'StakeWithdrawalLockingPeriod') != null
+    }
+}
+
+export class DomainsSudoIdConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    get isV2() {
+        return this._chain.getConstantTypeHash('Domains', 'SudoId') === 'cc28a7f7046ec4d0eb3419e4aa142bf25c25992e58d0e8646eb029c7c6b4c0c8'
+    }
+
+    get asV2(): Uint8Array {
+        assert(this.isV2)
+        return this._chain.getConstant('Domains', 'SudoId')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'SudoId') != null
+    }
+}
+
+export class DomainsTreasuryAccountConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Treasury account.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Domains', 'TreasuryAccount') === 'cc28a7f7046ec4d0eb3419e4aa142bf25c25992e58d0e8646eb029c7c6b4c0c8'
+    }
+
+    /**
+     *  Treasury account.
+     */
+    get asV1(): Uint8Array {
+        assert(this.isV1)
+        return this._chain.getConstant('Domains', 'TreasuryAccount')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Domains', 'TreasuryAccount') != null
+    }
+}
+
 export class FeedsMaxFeedsConstant {
     private readonly _chain: Chain
 
@@ -175,74 +707,6 @@ export class FeedsMaxFeedsConstant {
      */
     get isExists(): boolean {
         return this._chain.getConstantTypeHash('Feeds', 'MaxFeeds') != null
-    }
-}
-
-export class ReceiptsMaximumReceiptDriftConstant {
-    private readonly _chain: Chain
-
-    constructor(ctx: ChainContext) {
-        this._chain = ctx._chain
-    }
-
-    /**
-     *  Maximum execution receipt drift.
-     * 
-     *  If the primary number of an execution receipt plus the maximum drift is bigger than the
-     *  best execution chain number, this receipt will be rejected as being too far in the
-     *  future.
-     */
-    get isV1() {
-        return this._chain.getConstantTypeHash('Receipts', 'MaximumReceiptDrift') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
-    }
-
-    /**
-     *  Maximum execution receipt drift.
-     * 
-     *  If the primary number of an execution receipt plus the maximum drift is bigger than the
-     *  best execution chain number, this receipt will be rejected as being too far in the
-     *  future.
-     */
-    get asV1(): number {
-        assert(this.isV1)
-        return this._chain.getConstant('Receipts', 'MaximumReceiptDrift')
-    }
-
-    /**
-     * Checks whether the constant is defined for the current chain version.
-     */
-    get isExists(): boolean {
-        return this._chain.getConstantTypeHash('Receipts', 'MaximumReceiptDrift') != null
-    }
-}
-
-export class ReceiptsReceiptsPruningDepthConstant {
-    private readonly _chain: Chain
-
-    constructor(ctx: ChainContext) {
-        this._chain = ctx._chain
-    }
-
-    /**
-     *  Number of execution receipts kept in the state.
-     */
-    get isV1() {
-        return this._chain.getConstantTypeHash('Receipts', 'ReceiptsPruningDepth') === 'b76f37d33f64f2d9b3234e29034ab4a73ee9da01a61ab139c27f8c841971e469'
-    }
-
-    /**
-     *  Number of execution receipts kept in the state.
-     */
-    get asV1(): number {
-        assert(this.isV1)
-        return this._chain.getConstant('Receipts', 'ReceiptsPruningDepth')
-    }
-
-    /**
-     * Checks whether the constant is defined for the current chain version.
-     */
-    get isExists(): boolean {
-        return this._chain.getConstantTypeHash('Receipts', 'ReceiptsPruningDepth') != null
     }
 }
 
@@ -499,6 +963,126 @@ export class SubspaceInitialSolutionRangeConstant {
      */
     get isExists(): boolean {
         return this._chain.getConstantTypeHash('Subspace', 'InitialSolutionRange') != null
+    }
+}
+
+export class SubspaceMaxPiecesInSectorConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  How many pieces one sector is supposed to contain (max)
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Subspace', 'MaxPiecesInSector') === '32def12560ecd411fe2fc796552e97d0d5ee0ea10e059b3d8918c9e94dfdb334'
+    }
+
+    /**
+     *  How many pieces one sector is supposed to contain (max)
+     */
+    get asV1(): number {
+        assert(this.isV1)
+        return this._chain.getConstant('Subspace', 'MaxPiecesInSector')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Subspace', 'MaxPiecesInSector') != null
+    }
+}
+
+export class SubspaceMinSectorLifetimeConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Minimum lifetime of a plotted sector, measured in archived segment.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Subspace', 'MinSectorLifetime') === '2e8052d0ae8d237ad263438f986208df52f4f0e9f529557036c3b179dfb42f21'
+    }
+
+    /**
+     *  Minimum lifetime of a plotted sector, measured in archived segment.
+     */
+    get asV1(): bigint {
+        assert(this.isV1)
+        return this._chain.getConstant('Subspace', 'MinSectorLifetime')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Subspace', 'MinSectorLifetime') != null
+    }
+}
+
+export class SubspaceRecentHistoryFractionConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Subspace', 'RecentHistoryFraction') === 'ef51d55268ea048d2630ef91aec23cd3a982e0efd12a9169a7d12285ca9c59f4'
+    }
+
+    /**
+     *  Fraction of pieces from the "recent history" (`recent_segments`) in each sector.
+     */
+    get asV1(): [bigint, bigint] {
+        assert(this.isV1)
+        return this._chain.getConstant('Subspace', 'RecentHistoryFraction')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Subspace', 'RecentHistoryFraction') != null
+    }
+}
+
+export class SubspaceRecentSegmentsConstant {
+    private readonly _chain: Chain
+
+    constructor(ctx: ChainContext) {
+        this._chain = ctx._chain
+    }
+
+    /**
+     *  Number of latest archived segments that are considered "recent history".
+     */
+    get isV1() {
+        return this._chain.getConstantTypeHash('Subspace', 'RecentSegments') === '2e8052d0ae8d237ad263438f986208df52f4f0e9f529557036c3b179dfb42f21'
+    }
+
+    /**
+     *  Number of latest archived segments that are considered "recent history".
+     */
+    get asV1(): bigint {
+        assert(this.isV1)
+        return this._chain.getConstant('Subspace', 'RecentSegments')
+    }
+
+    /**
+     * Checks whether the constant is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this._chain.getConstantTypeHash('Subspace', 'RecentSegments') != null
     }
 }
 

--- a/squid-blockexplorer/src/types/events.ts
+++ b/squid-blockexplorer/src/types/events.ts
@@ -1,7 +1,6 @@
 import assert from 'assert'
 import {Chain, ChainContext, EventContext, Event, Result, Option} from './support'
 import * as v1 from './v1'
-import * as v2 from './v2'
 
 export class BalancesBalanceSetEvent {
     private readonly _chain: Chain
@@ -20,29 +19,14 @@ export class BalancesBalanceSetEvent {
      * A balance was set by root.
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('Balances.BalanceSet') === '1e2b5d5a07046e6d6e5507661d3f3feaddfb41fc609a2336b24957322080ca77'
-    }
-
-    /**
-     * A balance was set by root.
-     */
-    get asV1(): {who: Uint8Array, free: bigint, reserved: bigint} {
-        assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-
-    /**
-     * A balance was set by root.
-     */
-    get isV2(): boolean {
         return this._chain.getEventHash('Balances.BalanceSet') === '8c52e43e845654720e1db5c5bd166f80eb777baf474e93ce4d20fd385601a8fb'
     }
 
     /**
      * A balance was set by root.
      */
-    get asV2(): {who: Uint8Array, free: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array, free: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -63,15 +47,15 @@ export class BalancesBurnedEvent {
     /**
      * Some amount was burned from an account.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Burned') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
     }
 
     /**
      * Some amount was burned from an account.
      */
-    get asV2(): {who: Uint8Array, amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -165,6 +149,35 @@ export class BalancesEndowedEvent {
     }
 }
 
+export class BalancesFrozenEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Balances.Frozen')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Some balance was frozen.
+     */
+    get isV1(): boolean {
+        return this._chain.getEventHash('Balances.Frozen') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
+    }
+
+    /**
+     * Some balance was frozen.
+     */
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
 export class BalancesIssuedEvent {
     private readonly _chain: Chain
     private readonly event: Event
@@ -181,15 +194,15 @@ export class BalancesIssuedEvent {
     /**
      * Total issuance was increased by `amount`, creating a credit to be balanced.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Issued') === 'a3bdd43eed59e7b65720eef9b2dfe72389ca71ac9dbe7fe2874438aae4f18886'
     }
 
     /**
      * Total issuance was increased by `amount`, creating a credit to be balanced.
      */
-    get asV2(): {amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -210,15 +223,15 @@ export class BalancesLockedEvent {
     /**
      * Some balance was locked.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Locked') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
     }
 
     /**
      * Some balance was locked.
      */
-    get asV2(): {who: Uint8Array, amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -239,15 +252,15 @@ export class BalancesMintedEvent {
     /**
      * Some amount was minted into an account.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Minted') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
     }
 
     /**
      * Some amount was minted into an account.
      */
-    get asV2(): {who: Uint8Array, amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -268,15 +281,15 @@ export class BalancesRescindedEvent {
     /**
      * Total issuance was decreased by `amount`, creating a debt to be balanced.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Rescinded') === 'a3bdd43eed59e7b65720eef9b2dfe72389ca71ac9dbe7fe2874438aae4f18886'
     }
 
     /**
      * Total issuance was decreased by `amount`, creating a debt to be balanced.
      */
-    get asV2(): {amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -357,15 +370,15 @@ export class BalancesRestoredEvent {
     /**
      * Some amount was restored into an account.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Restored') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
     }
 
     /**
      * Some amount was restored into an account.
      */
-    get asV2(): {who: Uint8Array, amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -415,15 +428,44 @@ export class BalancesSuspendedEvent {
     /**
      * Some amount was suspended from an account (it can be restored later).
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Suspended') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
     }
 
     /**
      * Some amount was suspended from an account (it can be restored later).
      */
-    get asV2(): {who: Uint8Array, amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class BalancesThawedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Balances.Thawed')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Some balance was thawed.
+     */
+    get isV1(): boolean {
+        return this._chain.getEventHash('Balances.Thawed') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
+    }
+
+    /**
+     * Some balance was thawed.
+     */
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -473,15 +515,15 @@ export class BalancesUnlockedEvent {
     /**
      * Some balance was unlocked.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Unlocked') === 'e84a34a6a3d577b31f16557bd304282f4fe4cbd7115377f4687635dc48e52ba5'
     }
 
     /**
      * Some balance was unlocked.
      */
-    get asV2(): {who: Uint8Array, amount: bigint} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array, amount: bigint} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -531,15 +573,15 @@ export class BalancesUpgradedEvent {
     /**
      * An account was upgraded.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this._chain.getEventHash('Balances.Upgraded') === 'b8a0d2208835f6ada60dd21cd93533d703777b3779109a7c6a2f26bad68c2f3b'
     }
 
     /**
      * An account was upgraded.
      */
-    get asV2(): {who: Uint8Array} {
-        assert(this.isV2)
+    get asV1(): {who: Uint8Array} {
+        assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -573,35 +615,6 @@ export class BalancesWithdrawEvent {
     }
 }
 
-export class DomainsBundleEquivocationProofProcessedEvent {
-    private readonly _chain: Chain
-    private readonly event: Event
-
-    constructor(ctx: EventContext)
-    constructor(ctx: ChainContext, event: Event)
-    constructor(ctx: EventContext, event?: Event) {
-        event = event || ctx.event
-        assert(event.name === 'Domains.BundleEquivocationProofProcessed')
-        this._chain = ctx._chain
-        this.event = event
-    }
-
-    /**
-     * A bundle equivocation proof was processed.
-     */
-    get isV1(): boolean {
-        return this._chain.getEventHash('Domains.BundleEquivocationProofProcessed') === '01f2f9c28aa1d4d36a81ff042620b6677d25bf07c2bf4acc37b58658778a4fca'
-    }
-
-    /**
-     * A bundle equivocation proof was processed.
-     */
-    get asV1(): null {
-        assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-}
-
 export class DomainsBundleStoredEvent {
     private readonly _chain: Chain
     private readonly event: Event
@@ -619,19 +632,19 @@ export class DomainsBundleStoredEvent {
      * A domain bundle was included.
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('Domains.BundleStored') === 'c7902f39bcf2d9d73482bb09696b6123ae56c3de573a1db1869402cdc2a0b3c6'
+        return this._chain.getEventHash('Domains.BundleStored') === '77b3a0cb165b2ed52f524a2328625f604ec2360c2aef78db15de1f3af4950455'
     }
 
     /**
      * A domain bundle was included.
      */
-    get asV1(): {domainId: number, bundleHash: Uint8Array, bundleAuthor: Uint8Array} {
+    get asV1(): {domainId: number, bundleHash: Uint8Array, bundleAuthor: bigint} {
         assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
 }
 
-export class DomainsInvalidTransactionProofProcessedEvent {
+export class DomainsDomainEpochCompletedEvent {
     private readonly _chain: Chain
     private readonly event: Event
 
@@ -639,22 +652,269 @@ export class DomainsInvalidTransactionProofProcessedEvent {
     constructor(ctx: ChainContext, event: Event)
     constructor(ctx: EventContext, event?: Event) {
         event = event || ctx.event
-        assert(event.name === 'Domains.InvalidTransactionProofProcessed')
+        assert(event.name === 'Domains.DomainEpochCompleted')
         this._chain = ctx._chain
         this.event = event
     }
 
-    /**
-     * An invalid transaction proof was processed.
-     */
     get isV1(): boolean {
-        return this._chain.getEventHash('Domains.InvalidTransactionProofProcessed') === '01f2f9c28aa1d4d36a81ff042620b6677d25bf07c2bf4acc37b58658778a4fca'
+        return this._chain.getEventHash('Domains.DomainEpochCompleted') === '6641f9112d3517683ff0183b2260fcd2e90ac07c3d64e78842dfa8f1305b1a57'
     }
 
-    /**
-     * An invalid transaction proof was processed.
-     */
-    get asV1(): null {
+    get asV1(): {domainId: number, completedEpochIndex: number} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsDomainInstantiatedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.DomainInstantiated')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.DomainInstantiated') === '3037d4816636b5c3fb65811d3539dec2cca52f588262804bf1cbf515a78108bb'
+    }
+
+    get asV1(): {domainId: number} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsDomainRuntimeCreatedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.DomainRuntimeCreated')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.DomainRuntimeCreated') === 'fa98444b8d2d5668ec750959d5e4d2c10870e00fd321c8c4b34d28f2a0cde674'
+    }
+
+    get asV1(): {runtimeId: number, runtimeType: v1.RuntimeType} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsDomainRuntimeUpgradeScheduledEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.DomainRuntimeUpgradeScheduled')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.DomainRuntimeUpgradeScheduled') === '0e9e2f52937c6b7d278d7e6e8889b7976b67105c48b931b9c724dfdb418c6c68'
+    }
+
+    get asV1(): {runtimeId: number, scheduledAt: number} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsDomainRuntimeUpgradedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.DomainRuntimeUpgraded')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.DomainRuntimeUpgraded') === 'b2a97b0e43e4ac095c1d5d2a9b052e0a4aca1b2870c0b20768eeb3dcacc685c5'
+    }
+
+    get asV1(): {runtimeId: number} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsOperatorDeregisteredEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.OperatorDeregistered')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.OperatorDeregistered') === '8ffd479fbc1b33b18b9485df09465e8f37e733ec4184266f9bbe335de066f5ec'
+    }
+
+    get asV1(): {operatorId: bigint} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsOperatorNominatedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.OperatorNominated')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.OperatorNominated') === '70e95936f842f9d6e0fb3cf376c695c17ef475eadb689739f4d0d35e7887fcad'
+    }
+
+    get asV1(): {operatorId: bigint, nominatorId: Uint8Array} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsOperatorRegisteredEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.OperatorRegistered')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.OperatorRegistered') === 'd27b30266d3acce0e9ed794b5c4e3cf04c4b84f97072bb7fcbae02f17dfa9b1f'
+    }
+
+    get asV1(): {operatorId: bigint, domainId: number} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsOperatorRewardedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.OperatorRewarded')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.OperatorRewarded') === 'b9eed1de2e05d0c8ec956e512420c3b6f8ca02565e985fd21a7f1e95c2622037'
+    }
+
+    get asV1(): {operatorId: bigint, reward: bigint} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsOperatorSwitchedDomainEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.OperatorSwitchedDomain')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.OperatorSwitchedDomain') === '77423adbeca85a39e75117a3571e4dcc42b1c62fd6b500c5a02ba73710623744'
+    }
+
+    get asV1(): {oldDomainId: number, newDomainId: number} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsPreferredOperatorEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.PreferredOperator')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.PreferredOperator') === '70e95936f842f9d6e0fb3cf376c695c17ef475eadb689739f4d0d35e7887fcad'
+    }
+
+    get asV1(): {operatorId: bigint, nominatorId: Uint8Array} {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DomainsWithdrewStakeEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Domains.WithdrewStake')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    get isV1(): boolean {
+        return this._chain.getEventHash('Domains.WithdrewStake') === '70e95936f842f9d6e0fb3cf376c695c17ef475eadb689739f4d0d35e7887fcad'
+    }
+
+    get asV1(): {operatorId: bigint, nominatorId: Uint8Array} {
         assert(this.isV1)
         return this._chain.decodeEvent(this.event)
     }
@@ -896,64 +1156,6 @@ export class OffencesSubspaceOffenceEvent {
     }
 }
 
-export class ReceiptsFraudProofProcessedEvent {
-    private readonly _chain: Chain
-    private readonly event: Event
-
-    constructor(ctx: EventContext)
-    constructor(ctx: ChainContext, event: Event)
-    constructor(ctx: EventContext, event?: Event) {
-        event = event || ctx.event
-        assert(event.name === 'Receipts.FraudProofProcessed')
-        this._chain = ctx._chain
-        this.event = event
-    }
-
-    /**
-     * A fraud proof was processed.
-     */
-    get isV1(): boolean {
-        return this._chain.getEventHash('Receipts.FraudProofProcessed') === 'a562970cc8703adfcd6b50763bc389e03a0154122533c163c0032f60030ca223'
-    }
-
-    /**
-     * A fraud proof was processed.
-     */
-    get asV1(): {domainId: number, newBestNumber: number, newBestHash: Uint8Array} {
-        assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-}
-
-export class ReceiptsNewDomainReceiptEvent {
-    private readonly _chain: Chain
-    private readonly event: Event
-
-    constructor(ctx: EventContext)
-    constructor(ctx: ChainContext, event: Event)
-    constructor(ctx: EventContext, event?: Event) {
-        event = event || ctx.event
-        assert(event.name === 'Receipts.NewDomainReceipt')
-        this._chain = ctx._chain
-        this.event = event
-    }
-
-    /**
-     * A new domain receipt.
-     */
-    get isV1(): boolean {
-        return this._chain.getEventHash('Receipts.NewDomainReceipt') === 'cb94a4a0e596547a66c63a881a36583ab36c6a882b721350ee3f5d6895045fba'
-    }
-
-    /**
-     * A new domain receipt.
-     */
-    get asV1(): {domainId: number, primaryNumber: number, primaryHash: Uint8Array} {
-        assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-}
-
 export class RewardsBlockRewardEvent {
     private readonly _chain: Chain
     private readonly event: Event
@@ -1116,29 +1318,14 @@ export class SudoSudidEvent {
      * A sudo just took place. \[result\]
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('Sudo.Sudid') === '1b4cd14e3ef27d194a19f72ca99c0748bad5378dacf5240cdcde1536e1d11dad'
+        return this._chain.getEventHash('Sudo.Sudid') === '3ecb430e21c76eb720064ac2294a31cf70178245416aa72891f2973dfab55b73'
     }
 
     /**
      * A sudo just took place. \[result\]
      */
-    get asV1(): {sudoResult: v1.Type_46} {
+    get asV1(): {sudoResult: v1.Type_47} {
         assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-
-    /**
-     * A sudo just took place. \[result\]
-     */
-    get isV2(): boolean {
-        return this._chain.getEventHash('Sudo.Sudid') === '46f705cf78f55862454e1c96cbd85624469e65d9c879c6278cf4b6428bc723a4'
-    }
-
-    /**
-     * A sudo just took place. \[result\]
-     */
-    get asV2(): {sudoResult: v2.Type_47} {
-        assert(this.isV2)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -1160,29 +1347,14 @@ export class SudoSudoAsDoneEvent {
      * A sudo just took place. \[result\]
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('Sudo.SudoAsDone') === '1b4cd14e3ef27d194a19f72ca99c0748bad5378dacf5240cdcde1536e1d11dad'
+        return this._chain.getEventHash('Sudo.SudoAsDone') === '3ecb430e21c76eb720064ac2294a31cf70178245416aa72891f2973dfab55b73'
     }
 
     /**
      * A sudo just took place. \[result\]
      */
-    get asV1(): {sudoResult: v1.Type_46} {
+    get asV1(): {sudoResult: v1.Type_47} {
         assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-
-    /**
-     * A sudo just took place. \[result\]
-     */
-    get isV2(): boolean {
-        return this._chain.getEventHash('Sudo.SudoAsDone') === '46f705cf78f55862454e1c96cbd85624469e65d9c879c6278cf4b6428bc723a4'
-    }
-
-    /**
-     * A sudo just took place. \[result\]
-     */
-    get asV2(): {sudoResult: v2.Type_47} {
-        assert(this.isV2)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -1233,7 +1405,7 @@ export class SystemExtrinsicFailedEvent {
      * An extrinsic failed.
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('System.ExtrinsicFailed') === '36c29895cd15b6f845bb064a671635ce07ef9de9648695c2803020e8510d0fb3'
+        return this._chain.getEventHash('System.ExtrinsicFailed') === '89ca818f689e3f6e085d8137a961f36cc94819777211c5c11cca985a448944b8'
     }
 
     /**
@@ -1241,21 +1413,6 @@ export class SystemExtrinsicFailedEvent {
      */
     get asV1(): {dispatchError: v1.DispatchError, dispatchInfo: v1.DispatchInfo} {
         assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-
-    /**
-     * An extrinsic failed.
-     */
-    get isV2(): boolean {
-        return this._chain.getEventHash('System.ExtrinsicFailed') === '3dbd96eefe1aa593b278d8684042e23a6a118e379fb5699dd871cf28fb627cd6'
-    }
-
-    /**
-     * An extrinsic failed.
-     */
-    get asV2(): {dispatchError: v2.DispatchError, dispatchInfo: v2.DispatchInfo} {
-        assert(this.isV2)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -1599,7 +1756,7 @@ export class UtilityBatchInterruptedEvent {
      * well as the error.
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('Utility.BatchInterrupted') === '14dbb9456065a44deeed159d4dbd21796ec92754c0494d698c9bcc529d0f7279'
+        return this._chain.getEventHash('Utility.BatchInterrupted') === '031f8c01ddd9491965bf6e6671d70381e70d55e6028aab52a937d1c3afeecb9f'
     }
 
     /**
@@ -1608,23 +1765,6 @@ export class UtilityBatchInterruptedEvent {
      */
     get asV1(): {index: number, error: v1.DispatchError} {
         assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-
-    /**
-     * Batch of dispatches did not complete fully. Index of first failing dispatch given, as
-     * well as the error.
-     */
-    get isV2(): boolean {
-        return this._chain.getEventHash('Utility.BatchInterrupted') === '55aa3365272ab00b66790b493c7489ead9e9c34bdcad0b48ee9755d3bd0d725e'
-    }
-
-    /**
-     * Batch of dispatches did not complete fully. Index of first failing dispatch given, as
-     * well as the error.
-     */
-    get asV2(): {index: number, error: v2.DispatchError} {
-        assert(this.isV2)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -1646,29 +1786,14 @@ export class UtilityDispatchedAsEvent {
      * A call was dispatched.
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('Utility.DispatchedAs') === 'd15218d9451baa25e4e3c2b30a15d679f7c3c9aa3d43b64b531831430663eb58'
+        return this._chain.getEventHash('Utility.DispatchedAs') === 'ee56f7174dc1a4631da3e5b48f323193771be6a702fb2ff1ff40459869d34a0e'
     }
 
     /**
      * A call was dispatched.
      */
-    get asV1(): {result: v1.Type_46} {
+    get asV1(): {result: v1.Type_47} {
         assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-
-    /**
-     * A call was dispatched.
-     */
-    get isV2(): boolean {
-        return this._chain.getEventHash('Utility.DispatchedAs') === 'e6b126b1d10869892737f36b23109c1b51d3828aeab399104c160e9f275d8049'
-    }
-
-    /**
-     * A call was dispatched.
-     */
-    get asV2(): {result: v2.Type_47} {
-        assert(this.isV2)
         return this._chain.decodeEvent(this.event)
     }
 }
@@ -1719,7 +1844,7 @@ export class UtilityItemFailedEvent {
      * A single item within a Batch of dispatches has completed with error.
      */
     get isV1(): boolean {
-        return this._chain.getEventHash('Utility.ItemFailed') === '58463e011dfd19c6786d4056e9e9452b33b4cb0fcf9c6e8c032e8ad7d16b0d34'
+        return this._chain.getEventHash('Utility.ItemFailed') === '4564a5412ce55535234d019dbd1d2999c5a9d6f452a565385d0c43e85d0dbf0b'
     }
 
     /**
@@ -1727,21 +1852,6 @@ export class UtilityItemFailedEvent {
      */
     get asV1(): {error: v1.DispatchError} {
         assert(this.isV1)
-        return this._chain.decodeEvent(this.event)
-    }
-
-    /**
-     * A single item within a Batch of dispatches has completed with error.
-     */
-    get isV2(): boolean {
-        return this._chain.getEventHash('Utility.ItemFailed') === '3ea595fddebcb407af8f717186084e8c4f09481ff7bcc5d4cc97dcd83cddd616'
-    }
-
-    /**
-     * A single item within a Batch of dispatches has completed with error.
-     */
-    get asV2(): {error: v2.DispatchError} {
-        assert(this.isV2)
         return this._chain.decodeEvent(this.event)
     }
 }

--- a/squid-blockexplorer/src/types/storage.ts
+++ b/squid-blockexplorer/src/types/storage.ts
@@ -1,7 +1,6 @@
 import assert from 'assert'
 import {Block, BlockContext, Chain, ChainContext, Option, Result, StorageBase} from './support'
 import * as v1 from './v1'
-import * as v2 from './v2'
 
 export class BalancesAccountStorage extends StorageBase {
     protected getPrefix() {
@@ -39,7 +38,7 @@ export class BalancesAccountStorage extends StorageBase {
      *  NOTE: This is only used in the case that this pallet is used to store balances.
      */
     get isV1(): boolean {
-        return this.getTypeHash() === '0b3b4bf0dd7388459eba461bc7c3226bf58608c941710a714e02f33ec0f91e78'
+        return this.getTypeHash() === '12d9e780c790f66e9c340b94cabd98da447e1087819d4acb4b1fe22bbb2783fb'
     }
 
     /**
@@ -70,67 +69,6 @@ export class BalancesAccountStorage extends StorageBase {
      */
     get asV1(): BalancesAccountStorageV1 {
         assert(this.isV1)
-        return this as any
-    }
-
-    /**
-     *  The Balances pallet example of storing the balance of an account.
-     * 
-     *  # Example
-     * 
-     *  ```nocompile
-     *   impl pallet_balances::Config for Runtime {
-     *     type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>
-     *   }
-     *  ```
-     * 
-     *  You can also store the balance of an account in the `System` pallet.
-     * 
-     *  # Example
-     * 
-     *  ```nocompile
-     *   impl pallet_balances::Config for Runtime {
-     *    type AccountStore = System
-     *   }
-     *  ```
-     * 
-     *  But this comes with tradeoffs, storing account balances in the system pallet stores
-     *  `frame_system` data alongside the account data contrary to storing account balances in the
-     *  `Balances` pallet, which uses a `StorageMap` to store balances data only.
-     *  NOTE: This is only used in the case that this pallet is used to store balances.
-     */
-    get isV2(): boolean {
-        return this.getTypeHash() === '12d9e780c790f66e9c340b94cabd98da447e1087819d4acb4b1fe22bbb2783fb'
-    }
-
-    /**
-     *  The Balances pallet example of storing the balance of an account.
-     * 
-     *  # Example
-     * 
-     *  ```nocompile
-     *   impl pallet_balances::Config for Runtime {
-     *     type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>
-     *   }
-     *  ```
-     * 
-     *  You can also store the balance of an account in the `System` pallet.
-     * 
-     *  # Example
-     * 
-     *  ```nocompile
-     *   impl pallet_balances::Config for Runtime {
-     *    type AccountStore = System
-     *   }
-     *  ```
-     * 
-     *  But this comes with tradeoffs, storing account balances in the system pallet stores
-     *  `frame_system` data alongside the account data contrary to storing account balances in the
-     *  `Balances` pallet, which uses a `StorageMap` to store balances data only.
-     *  NOTE: This is only used in the case that this pallet is used to store balances.
-     */
-    get asV2(): BalancesAccountStorageV2 {
-        assert(this.isV2)
         return this as any
     }
 }
@@ -175,46 +113,6 @@ export interface BalancesAccountStorageV1 {
     getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v1.AccountData][]>
 }
 
-/**
- *  The Balances pallet example of storing the balance of an account.
- * 
- *  # Example
- * 
- *  ```nocompile
- *   impl pallet_balances::Config for Runtime {
- *     type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>
- *   }
- *  ```
- * 
- *  You can also store the balance of an account in the `System` pallet.
- * 
- *  # Example
- * 
- *  ```nocompile
- *   impl pallet_balances::Config for Runtime {
- *    type AccountStore = System
- *   }
- *  ```
- * 
- *  But this comes with tradeoffs, storing account balances in the system pallet stores
- *  `frame_system` data alongside the account data contrary to storing account balances in the
- *  `Balances` pallet, which uses a `StorageMap` to store balances data only.
- *  NOTE: This is only used in the case that this pallet is used to store balances.
- */
-export interface BalancesAccountStorageV2 {
-    get(key: Uint8Array): Promise<v2.AccountData>
-    getAll(): Promise<v2.AccountData[]>
-    getMany(keys: Uint8Array[]): Promise<v2.AccountData[]>
-    getKeys(): Promise<Uint8Array[]>
-    getKeys(key: Uint8Array): Promise<Uint8Array[]>
-    getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
-    getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
-    getPairs(): Promise<[k: Uint8Array, v: v2.AccountData][]>
-    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v2.AccountData][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v2.AccountData][]>
-    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v2.AccountData][]>
-}
-
 export class BalancesFreezesStorage extends StorageBase {
     protected getPrefix() {
         return 'Balances'
@@ -227,15 +125,15 @@ export class BalancesFreezesStorage extends StorageBase {
     /**
      *  Freeze locks on account balances.
      */
-    get isV2(): boolean {
+    get isV1(): boolean {
         return this.getTypeHash() === '687d129c824d7b23d1f21a471b19c3fed952e35b64e5de19f549851d1c3f7f91'
     }
 
     /**
      *  Freeze locks on account balances.
      */
-    get asV2(): BalancesFreezesStorageV2 {
-        assert(this.isV2)
+    get asV1(): BalancesFreezesStorageV1 {
+        assert(this.isV1)
         return this as any
     }
 }
@@ -243,18 +141,18 @@ export class BalancesFreezesStorage extends StorageBase {
 /**
  *  Freeze locks on account balances.
  */
-export interface BalancesFreezesStorageV2 {
-    get(key: Uint8Array): Promise<v2.IdAmount[]>
-    getAll(): Promise<v2.IdAmount[][]>
-    getMany(keys: Uint8Array[]): Promise<v2.IdAmount[][]>
+export interface BalancesFreezesStorageV1 {
+    get(key: Uint8Array): Promise<v1.Type_139[]>
+    getAll(): Promise<v1.Type_139[][]>
+    getMany(keys: Uint8Array[]): Promise<v1.Type_139[][]>
     getKeys(): Promise<Uint8Array[]>
     getKeys(key: Uint8Array): Promise<Uint8Array[]>
     getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
     getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
-    getPairs(): Promise<[k: Uint8Array, v: v2.IdAmount[]][]>
-    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v2.IdAmount[]][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v2.IdAmount[]][]>
-    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v2.IdAmount[]][]>
+    getPairs(): Promise<[k: Uint8Array, v: v1.Type_139[]][]>
+    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v1.Type_139[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v1.Type_139[]][]>
+    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v1.Type_139[]][]>
 }
 
 export class BalancesHoldsStorage extends StorageBase {
@@ -269,15 +167,15 @@ export class BalancesHoldsStorage extends StorageBase {
     /**
      *  Holds on account balances.
      */
-    get isV2(): boolean {
-        return this.getTypeHash() === '687d129c824d7b23d1f21a471b19c3fed952e35b64e5de19f549851d1c3f7f91'
+    get isV1(): boolean {
+        return this.getTypeHash() === '204d8b02a648a7c6c7ea18a95de1d1370bad45f7a952604eef5f4a2a423f7888'
     }
 
     /**
      *  Holds on account balances.
      */
-    get asV2(): BalancesHoldsStorageV2 {
-        assert(this.isV2)
+    get asV1(): BalancesHoldsStorageV1 {
+        assert(this.isV1)
         return this as any
     }
 }
@@ -285,18 +183,18 @@ export class BalancesHoldsStorage extends StorageBase {
 /**
  *  Holds on account balances.
  */
-export interface BalancesHoldsStorageV2 {
-    get(key: Uint8Array): Promise<v2.IdAmount[]>
-    getAll(): Promise<v2.IdAmount[][]>
-    getMany(keys: Uint8Array[]): Promise<v2.IdAmount[][]>
+export interface BalancesHoldsStorageV1 {
+    get(key: Uint8Array): Promise<v1.IdAmount[]>
+    getAll(): Promise<v1.IdAmount[][]>
+    getMany(keys: Uint8Array[]): Promise<v1.IdAmount[][]>
     getKeys(): Promise<Uint8Array[]>
     getKeys(key: Uint8Array): Promise<Uint8Array[]>
     getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
     getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
-    getPairs(): Promise<[k: Uint8Array, v: v2.IdAmount[]][]>
-    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v2.IdAmount[]][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v2.IdAmount[]][]>
-    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v2.IdAmount[]][]>
+    getPairs(): Promise<[k: Uint8Array, v: v1.IdAmount[]][]>
+    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v1.IdAmount[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v1.IdAmount[]][]>
+    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v1.IdAmount[]][]>
 }
 
 export class BalancesInactiveIssuanceStorage extends StorageBase {
@@ -448,6 +346,1384 @@ export class BalancesTotalIssuanceStorage extends StorageBase {
  */
 export interface BalancesTotalIssuanceStorageV1 {
     get(): Promise<bigint>
+}
+
+export class DomainsBlockTreeStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'BlockTree'
+    }
+
+    /**
+     *  The domain block tree, map (`domain_id`, `domain_block_number`) to the hash of a domain blocks,
+     *  which can be used get the domain block in `DomainBlocks`
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '05816b1bdbe11d0e04ffb446adba22a68ff9fd377cc1a4c8b4ea29e5605f0978'
+    }
+
+    /**
+     *  The domain block tree, map (`domain_id`, `domain_block_number`) to the hash of a domain blocks,
+     *  which can be used get the domain block in `DomainBlocks`
+     */
+    get asV1(): DomainsBlockTreeStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The domain block tree, map (`domain_id`, `domain_block_number`) to the hash of a domain blocks,
+ *  which can be used get the domain block in `DomainBlocks`
+ */
+export interface DomainsBlockTreeStorageV1 {
+    get(key1: number, key2: number): Promise<Uint8Array[]>
+    getAll(): Promise<Uint8Array[][]>
+    getMany(keys: [number, number][]): Promise<Uint8Array[][]>
+    getKeys(): Promise<[number, number][]>
+    getKeys(key1: number): Promise<[number, number][]>
+    getKeys(key1: number, key2: number): Promise<[number, number][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[number, number][]>
+    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, number][]>
+    getKeysPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[number, number][]>
+    getPairs(): Promise<[k: [number, number], v: Uint8Array[]][]>
+    getPairs(key1: number): Promise<[k: [number, number], v: Uint8Array[]][]>
+    getPairs(key1: number, key2: number): Promise<[k: [number, number], v: Uint8Array[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number], v: Uint8Array[]][]>
+    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, number], v: Uint8Array[]][]>
+    getPairsPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[k: [number, number], v: Uint8Array[]][]>
+}
+
+export class DomainsConsensusBlockHashStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'ConsensusBlockHash'
+    }
+
+    /**
+     *  The consensus block hash used to verify ER, only store the consensus block hash for a domain
+     *  if that consensus block contains bundle of the domain, the hash will be pruned when the ER
+     *  that point to the consensus block is pruned.
+     * 
+     *  TODO: this storage is unbounded in some cases, see https://github.com/subspace/subspace/issues/1673
+     *  for more details, this will be fixed once https://github.com/subspace/subspace/issues/1731 is implemented.
+     */
+    get isV2(): boolean {
+        return this.getTypeHash() === 'b3c15232fb4346b458fc3153a06d89787a103676fa34fe3d795ee04fe62bf4d8'
+    }
+
+    /**
+     *  The consensus block hash used to verify ER, only store the consensus block hash for a domain
+     *  if that consensus block contains bundle of the domain, the hash will be pruned when the ER
+     *  that point to the consensus block is pruned.
+     * 
+     *  TODO: this storage is unbounded in some cases, see https://github.com/subspace/subspace/issues/1673
+     *  for more details, this will be fixed once https://github.com/subspace/subspace/issues/1731 is implemented.
+     */
+    get asV2(): DomainsConsensusBlockHashStorageV2 {
+        assert(this.isV2)
+        return this as any
+    }
+}
+
+/**
+ *  The consensus block hash used to verify ER, only store the consensus block hash for a domain
+ *  if that consensus block contains bundle of the domain, the hash will be pruned when the ER
+ *  that point to the consensus block is pruned.
+ * 
+ *  TODO: this storage is unbounded in some cases, see https://github.com/subspace/subspace/issues/1673
+ *  for more details, this will be fixed once https://github.com/subspace/subspace/issues/1731 is implemented.
+ */
+export interface DomainsConsensusBlockHashStorageV2 {
+    get(key1: number, key2: number): Promise<(Uint8Array | undefined)>
+    getAll(): Promise<Uint8Array[]>
+    getMany(keys: [number, number][]): Promise<(Uint8Array | undefined)[]>
+    getKeys(): Promise<[number, number][]>
+    getKeys(key1: number): Promise<[number, number][]>
+    getKeys(key1: number, key2: number): Promise<[number, number][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[number, number][]>
+    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, number][]>
+    getKeysPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[number, number][]>
+    getPairs(): Promise<[k: [number, number], v: Uint8Array][]>
+    getPairs(key1: number): Promise<[k: [number, number], v: Uint8Array][]>
+    getPairs(key1: number, key2: number): Promise<[k: [number, number], v: Uint8Array][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number], v: Uint8Array][]>
+    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, number], v: Uint8Array][]>
+    getPairsPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[k: [number, number], v: Uint8Array][]>
+}
+
+export class DomainsDomainBlocksStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'DomainBlocks'
+    }
+
+    /**
+     *  Mapping of domain block hash to domain block
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'd5954976577ef6008eae68925c8ea2df190e3c1c20c06b4f90908dad82f85f82'
+    }
+
+    /**
+     *  Mapping of domain block hash to domain block
+     */
+    get asV1(): DomainsDomainBlocksStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Mapping of domain block hash to domain block
+ */
+export interface DomainsDomainBlocksStorageV1 {
+    get(key: Uint8Array): Promise<(v1.DomainBlock | undefined)>
+    getAll(): Promise<v1.DomainBlock[]>
+    getMany(keys: Uint8Array[]): Promise<(v1.DomainBlock | undefined)[]>
+    getKeys(): Promise<Uint8Array[]>
+    getKeys(key: Uint8Array): Promise<Uint8Array[]>
+    getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
+    getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
+    getPairs(): Promise<[k: Uint8Array, v: v1.DomainBlock][]>
+    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v1.DomainBlock][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v1.DomainBlock][]>
+    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v1.DomainBlock][]>
+}
+
+export class DomainsDomainRegistryStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'DomainRegistry'
+    }
+
+    /**
+     *  The domain registry
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '937fa268778e9673ff30aa878ba1c724c80976066fcf3f7cb0aa6c40fb1e3dba'
+    }
+
+    /**
+     *  The domain registry
+     */
+    get asV1(): DomainsDomainRegistryStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The domain registry
+ */
+export interface DomainsDomainRegistryStorageV1 {
+    get(key: number): Promise<(v1.DomainObject | undefined)>
+    getAll(): Promise<v1.DomainObject[]>
+    getMany(keys: number[]): Promise<(v1.DomainObject | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: v1.DomainObject][]>
+    getPairs(key: number): Promise<[k: number, v: v1.DomainObject][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: v1.DomainObject][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: v1.DomainObject][]>
+}
+
+export class DomainsDomainStakingSummaryStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'DomainStakingSummary'
+    }
+
+    get isV1(): boolean {
+        return this.getTypeHash() === 'e4962a38125d72bf8ec89ca7af661a9db43cf468454deb464cf1ed90d927f1ce'
+    }
+
+    get asV1(): DomainsDomainStakingSummaryStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+export interface DomainsDomainStakingSummaryStorageV1 {
+    get(key: number): Promise<(v1.StakingSummary | undefined)>
+    getAll(): Promise<v1.StakingSummary[]>
+    getMany(keys: number[]): Promise<(v1.StakingSummary | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: v1.StakingSummary][]>
+    getPairs(key: number): Promise<[k: number, v: v1.StakingSummary][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: v1.StakingSummary][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: v1.StakingSummary][]>
+}
+
+export class DomainsDomainTxRangeStateStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'DomainTxRangeState'
+    }
+
+    get isV1(): boolean {
+        return this.getTypeHash() === 'b33cdcbf1fbd2a196f953b48092bb36b14bbe6dbd0c45cc4d40b7ce6e2597eac'
+    }
+
+    get asV1(): DomainsDomainTxRangeStateStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+export interface DomainsDomainTxRangeStateStorageV1 {
+    get(key: number): Promise<(v1.TxRangeState | undefined)>
+    getAll(): Promise<v1.TxRangeState[]>
+    getMany(keys: number[]): Promise<(v1.TxRangeState | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: v1.TxRangeState][]>
+    getPairs(key: number): Promise<[k: number, v: v1.TxRangeState][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: v1.TxRangeState][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: v1.TxRangeState][]>
+}
+
+export class DomainsExecutionInboxStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'ExecutionInbox'
+    }
+
+    /**
+     *  A set of `BundleDigest` from all bundles that successfully submitted to the consensus block,
+     *  these bundles will be used to construct the domain block and `ExecutionInbox` is used to:
+     * 
+     *  1. Ensure subsequent ERs of that domain block include all pre-validated extrinsic bundles
+     *  2. Index the `InboxedBundle` and pruned its value when the corresponding `ExecutionInbox` is pruned
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'e1e2e7abf454f1f0d62f4d39fcd2fa276b68b422339f8d57dbfff3d55cbe9812'
+    }
+
+    /**
+     *  A set of `BundleDigest` from all bundles that successfully submitted to the consensus block,
+     *  these bundles will be used to construct the domain block and `ExecutionInbox` is used to:
+     * 
+     *  1. Ensure subsequent ERs of that domain block include all pre-validated extrinsic bundles
+     *  2. Index the `InboxedBundle` and pruned its value when the corresponding `ExecutionInbox` is pruned
+     */
+    get asV1(): DomainsExecutionInboxStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  A set of `BundleDigest` from all bundles that successfully submitted to the consensus block,
+ *  these bundles will be used to construct the domain block and `ExecutionInbox` is used to:
+ * 
+ *  1. Ensure subsequent ERs of that domain block include all pre-validated extrinsic bundles
+ *  2. Index the `InboxedBundle` and pruned its value when the corresponding `ExecutionInbox` is pruned
+ */
+export interface DomainsExecutionInboxStorageV1 {
+    get(key1: number, key2: number, key3: number): Promise<v1.BundleDigest[]>
+    getAll(): Promise<v1.BundleDigest[][]>
+    getMany(keys: [number, number, number][]): Promise<v1.BundleDigest[][]>
+    getKeys(): Promise<[number, number, number][]>
+    getKeys(key1: number): Promise<[number, number, number][]>
+    getKeys(key1: number, key2: number): Promise<[number, number, number][]>
+    getKeys(key1: number, key2: number, key3: number): Promise<[number, number, number][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[number, number, number][]>
+    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, number, number][]>
+    getKeysPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[number, number, number][]>
+    getKeysPaged(pageSize: number, key1: number, key2: number, key3: number): AsyncIterable<[number, number, number][]>
+    getPairs(): Promise<[k: [number, number, number], v: v1.BundleDigest[]][]>
+    getPairs(key1: number): Promise<[k: [number, number, number], v: v1.BundleDigest[]][]>
+    getPairs(key1: number, key2: number): Promise<[k: [number, number, number], v: v1.BundleDigest[]][]>
+    getPairs(key1: number, key2: number, key3: number): Promise<[k: [number, number, number], v: v1.BundleDigest[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number, number], v: v1.BundleDigest[]][]>
+    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, number, number], v: v1.BundleDigest[]][]>
+    getPairsPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[k: [number, number, number], v: v1.BundleDigest[]][]>
+    getPairsPaged(pageSize: number, key1: number, key2: number, key3: number): AsyncIterable<[k: [number, number, number], v: v1.BundleDigest[]][]>
+}
+
+export class DomainsHeadDomainNumberStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'HeadDomainNumber'
+    }
+
+    /**
+     *  The block number of the best domain block, increase by one when the first bundle of the domain is
+     *  successfully submitted to current consensus block, which mean a new domain block with this block
+     *  number will be produce. Used as a pointer in `ExecutionInbox` to identify the current under building
+     *  domain block, also used as a mapping of consensus block number to domain block number.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'be37cd27c0e60862618e14817365ea9f5c3c45854fea63a6259de44af2521364'
+    }
+
+    /**
+     *  The block number of the best domain block, increase by one when the first bundle of the domain is
+     *  successfully submitted to current consensus block, which mean a new domain block with this block
+     *  number will be produce. Used as a pointer in `ExecutionInbox` to identify the current under building
+     *  domain block, also used as a mapping of consensus block number to domain block number.
+     */
+    get asV1(): DomainsHeadDomainNumberStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The block number of the best domain block, increase by one when the first bundle of the domain is
+ *  successfully submitted to current consensus block, which mean a new domain block with this block
+ *  number will be produce. Used as a pointer in `ExecutionInbox` to identify the current under building
+ *  domain block, also used as a mapping of consensus block number to domain block number.
+ */
+export interface DomainsHeadDomainNumberStorageV1 {
+    get(key: number): Promise<number>
+    getAll(): Promise<number[]>
+    getMany(keys: number[]): Promise<number[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: number][]>
+    getPairs(key: number): Promise<[k: number, v: number][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: number][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: number][]>
+}
+
+export class DomainsHeadReceiptNumberStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'HeadReceiptNumber'
+    }
+
+    /**
+     *  The head receipt number of each domain
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'be37cd27c0e60862618e14817365ea9f5c3c45854fea63a6259de44af2521364'
+    }
+
+    /**
+     *  The head receipt number of each domain
+     */
+    get asV1(): DomainsHeadReceiptNumberStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The head receipt number of each domain
+ */
+export interface DomainsHeadReceiptNumberStorageV1 {
+    get(key: number): Promise<number>
+    getAll(): Promise<number[]>
+    getMany(keys: number[]): Promise<number[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: number][]>
+    getPairs(key: number): Promise<[k: number, v: number][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: number][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: number][]>
+}
+
+export class DomainsInboxedBundleStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'InboxedBundle'
+    }
+
+    /**
+     *  A mapping of `bundle_header_hash` -> `bundle_author` for all the successfully submitted bundles of
+     *  the last `BlockTreePruningDepth` domain blocks. Used to verify the invalid bundle fraud proof and
+     *  slash malicious operator who have submitted invalid bundle.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'fc96d6750297129d4ff884dffc4742fe833e9be687fa34e80679655014942975'
+    }
+
+    /**
+     *  A mapping of `bundle_header_hash` -> `bundle_author` for all the successfully submitted bundles of
+     *  the last `BlockTreePruningDepth` domain blocks. Used to verify the invalid bundle fraud proof and
+     *  slash malicious operator who have submitted invalid bundle.
+     */
+    get asV1(): DomainsInboxedBundleStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  A mapping of `bundle_header_hash` -> `bundle_author` for all the successfully submitted bundles of
+ *  the last `BlockTreePruningDepth` domain blocks. Used to verify the invalid bundle fraud proof and
+ *  slash malicious operator who have submitted invalid bundle.
+ */
+export interface DomainsInboxedBundleStorageV1 {
+    get(key: Uint8Array): Promise<(bigint | undefined)>
+    getAll(): Promise<bigint[]>
+    getMany(keys: Uint8Array[]): Promise<(bigint | undefined)[]>
+    getKeys(): Promise<Uint8Array[]>
+    getKeys(key: Uint8Array): Promise<Uint8Array[]>
+    getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
+    getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
+    getPairs(): Promise<[k: Uint8Array, v: bigint][]>
+    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: bigint][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: bigint][]>
+    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: bigint][]>
+}
+
+export class DomainsLastEpochStakingDistributionStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'LastEpochStakingDistribution'
+    }
+
+    /**
+     *  A temporary storage to hold any previous epoch details for a given domain
+     *  if the epoch transitioned in this block so that all the submitted bundles
+     *  within this block are verified.
+     *  The storage is cleared on block finalization.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '3fbfed0280a211286cd7057803f571ba30eafa821c81988d3f7600945ba20260'
+    }
+
+    /**
+     *  A temporary storage to hold any previous epoch details for a given domain
+     *  if the epoch transitioned in this block so that all the submitted bundles
+     *  within this block are verified.
+     *  The storage is cleared on block finalization.
+     */
+    get asV1(): DomainsLastEpochStakingDistributionStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  A temporary storage to hold any previous epoch details for a given domain
+ *  if the epoch transitioned in this block so that all the submitted bundles
+ *  within this block are verified.
+ *  The storage is cleared on block finalization.
+ */
+export interface DomainsLastEpochStakingDistributionStorageV1 {
+    get(key: number): Promise<(v1.ElectionVerificationParams | undefined)>
+    getAll(): Promise<v1.ElectionVerificationParams[]>
+    getMany(keys: number[]): Promise<(v1.ElectionVerificationParams | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: v1.ElectionVerificationParams][]>
+    getPairs(key: number): Promise<[k: number, v: v1.ElectionVerificationParams][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: v1.ElectionVerificationParams][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: v1.ElectionVerificationParams][]>
+}
+
+export class DomainsNextDomainIdStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'NextDomainId'
+    }
+
+    /**
+     *  Stores the next domain id.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '81bbbe8e62451cbcc227306706c919527aa2538970bd6d67a9969dd52c257d02'
+    }
+
+    /**
+     *  Stores the next domain id.
+     */
+    get asV1(): DomainsNextDomainIdStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Stores the next domain id.
+ */
+export interface DomainsNextDomainIdStorageV1 {
+    get(): Promise<number>
+}
+
+export class DomainsNextOperatorIdStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'NextOperatorId'
+    }
+
+    get isV1(): boolean {
+        return this.getTypeHash() === '95ff4f914f08e149ddbe1ae2dcb1743bbf9aaae69d04c486e1a398cacfcca06a'
+    }
+
+    get asV1(): DomainsNextOperatorIdStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+export interface DomainsNextOperatorIdStorageV1 {
+    get(): Promise<bigint>
+}
+
+export class DomainsNextRuntimeIdStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'NextRuntimeId'
+    }
+
+    /**
+     *  Stores the next runtime id.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '81bbbe8e62451cbcc227306706c919527aa2538970bd6d67a9969dd52c257d02'
+    }
+
+    /**
+     *  Stores the next runtime id.
+     */
+    get asV1(): DomainsNextRuntimeIdStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Stores the next runtime id.
+ */
+export interface DomainsNextRuntimeIdStorageV1 {
+    get(): Promise<number>
+}
+
+export class DomainsNominatorsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'Nominators'
+    }
+
+    /**
+     *  List of all current epoch's nominators and their shares under a given operator,
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '462d3e1b8faa92cfc96b05dd4e3ea97ff60f30e122bfe01dc7fa29963d8ad049'
+    }
+
+    /**
+     *  List of all current epoch's nominators and their shares under a given operator,
+     */
+    get asV1(): DomainsNominatorsStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  List of all current epoch's nominators and their shares under a given operator,
+ */
+export interface DomainsNominatorsStorageV1 {
+    get(key1: bigint, key2: Uint8Array): Promise<(v1.Nominator | undefined)>
+    getAll(): Promise<v1.Nominator[]>
+    getMany(keys: [bigint, Uint8Array][]): Promise<(v1.Nominator | undefined)[]>
+    getKeys(): Promise<[bigint, Uint8Array][]>
+    getKeys(key1: bigint): Promise<[bigint, Uint8Array][]>
+    getKeys(key1: bigint, key2: Uint8Array): Promise<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number, key1: bigint): AsyncIterable<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number, key1: bigint, key2: Uint8Array): AsyncIterable<[bigint, Uint8Array][]>
+    getPairs(): Promise<[k: [bigint, Uint8Array], v: v1.Nominator][]>
+    getPairs(key1: bigint): Promise<[k: [bigint, Uint8Array], v: v1.Nominator][]>
+    getPairs(key1: bigint, key2: Uint8Array): Promise<[k: [bigint, Uint8Array], v: v1.Nominator][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [bigint, Uint8Array], v: v1.Nominator][]>
+    getPairsPaged(pageSize: number, key1: bigint): AsyncIterable<[k: [bigint, Uint8Array], v: v1.Nominator][]>
+    getPairsPaged(pageSize: number, key1: bigint, key2: Uint8Array): AsyncIterable<[k: [bigint, Uint8Array], v: v1.Nominator][]>
+}
+
+export class DomainsOperatorIdOwnerStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'OperatorIdOwner'
+    }
+
+    get isV1(): boolean {
+        return this.getTypeHash() === 'ffc087e1323413e73a9729e444bf115bb89bc74cab9f4347c9dc890a14ae8d68'
+    }
+
+    get asV1(): DomainsOperatorIdOwnerStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+export interface DomainsOperatorIdOwnerStorageV1 {
+    get(key: bigint): Promise<(Uint8Array | undefined)>
+    getAll(): Promise<Uint8Array[]>
+    getMany(keys: bigint[]): Promise<(Uint8Array | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: Uint8Array][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: Uint8Array][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: Uint8Array][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: Uint8Array][]>
+}
+
+export class DomainsOperatorsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'Operators'
+    }
+
+    /**
+     *  List of all registered operators and their configuration.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'd89f95a1a2e91948c86fb71302c209eab34daddac4e102e79d0f5833bb6e6d6e'
+    }
+
+    /**
+     *  List of all registered operators and their configuration.
+     */
+    get asV1(): DomainsOperatorsStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  List of all registered operators and their configuration.
+ */
+export interface DomainsOperatorsStorageV1 {
+    get(key: bigint): Promise<(v1.Operator | undefined)>
+    getAll(): Promise<v1.Operator[]>
+    getMany(keys: bigint[]): Promise<(v1.Operator | undefined)[]>
+    getKeys(): Promise<bigint[]>
+    getKeys(key: bigint): Promise<bigint[]>
+    getKeysPaged(pageSize: number): AsyncIterable<bigint[]>
+    getKeysPaged(pageSize: number, key: bigint): AsyncIterable<bigint[]>
+    getPairs(): Promise<[k: bigint, v: v1.Operator][]>
+    getPairs(key: bigint): Promise<[k: bigint, v: v1.Operator][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: bigint, v: v1.Operator][]>
+    getPairsPaged(pageSize: number, key: bigint): AsyncIterable<[k: bigint, v: v1.Operator][]>
+}
+
+export class DomainsPendingDepositsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingDeposits'
+    }
+
+    /**
+     *  Deposits initiated a nominator under this operator.
+     *  Will be stored temporarily until the current epoch is complete.
+     *  Once, epoch is complete, these deposits are staked beginning next epoch.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '3193c3ea200c934fac10ec318ae9e0f3f68648d492b8a4aae86f55259134365d'
+    }
+
+    /**
+     *  Deposits initiated a nominator under this operator.
+     *  Will be stored temporarily until the current epoch is complete.
+     *  Once, epoch is complete, these deposits are staked beginning next epoch.
+     */
+    get asV1(): DomainsPendingDepositsStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Deposits initiated a nominator under this operator.
+ *  Will be stored temporarily until the current epoch is complete.
+ *  Once, epoch is complete, these deposits are staked beginning next epoch.
+ */
+export interface DomainsPendingDepositsStorageV1 {
+    get(key1: bigint, key2: Uint8Array): Promise<(bigint | undefined)>
+    getAll(): Promise<bigint[]>
+    getMany(keys: [bigint, Uint8Array][]): Promise<(bigint | undefined)[]>
+    getKeys(): Promise<[bigint, Uint8Array][]>
+    getKeys(key1: bigint): Promise<[bigint, Uint8Array][]>
+    getKeys(key1: bigint, key2: Uint8Array): Promise<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number, key1: bigint): AsyncIterable<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number, key1: bigint, key2: Uint8Array): AsyncIterable<[bigint, Uint8Array][]>
+    getPairs(): Promise<[k: [bigint, Uint8Array], v: bigint][]>
+    getPairs(key1: bigint): Promise<[k: [bigint, Uint8Array], v: bigint][]>
+    getPairs(key1: bigint, key2: Uint8Array): Promise<[k: [bigint, Uint8Array], v: bigint][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [bigint, Uint8Array], v: bigint][]>
+    getPairsPaged(pageSize: number, key1: bigint): AsyncIterable<[k: [bigint, Uint8Array], v: bigint][]>
+    getPairsPaged(pageSize: number, key1: bigint, key2: Uint8Array): AsyncIterable<[k: [bigint, Uint8Array], v: bigint][]>
+}
+
+export class DomainsPendingGenesisDomainStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingGenesisDomain'
+    }
+
+    /**
+     *  The genesis domian that scheduled to register at block #1, should be removed once
+     *  https://github.com/paritytech/substrate/issues/14541 is resolved.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'f520f5afa6248eb18f3a23d51089d9f554686ada339d4ff29b00ebe448ce554f'
+    }
+
+    /**
+     *  The genesis domian that scheduled to register at block #1, should be removed once
+     *  https://github.com/paritytech/substrate/issues/14541 is resolved.
+     */
+    get asV1(): DomainsPendingGenesisDomainStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The genesis domian that scheduled to register at block #1, should be removed once
+ *  https://github.com/paritytech/substrate/issues/14541 is resolved.
+ */
+export interface DomainsPendingGenesisDomainStorageV1 {
+    get(): Promise<(v1.GenesisDomain | undefined)>
+}
+
+export class DomainsPendingNominatorUnlocksStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingNominatorUnlocks'
+    }
+
+    /**
+     *  All the pending unlocks for the nominators.
+     *  We use this storage to fetch all the pending unlocks under a operator pool at the time of slashing.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '1412d7a822d5726648202444dc5b043984742ced71e90d8517917acb144ec2dd'
+    }
+
+    /**
+     *  All the pending unlocks for the nominators.
+     *  We use this storage to fetch all the pending unlocks under a operator pool at the time of slashing.
+     */
+    get asV1(): DomainsPendingNominatorUnlocksStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  All the pending unlocks for the nominators.
+ *  We use this storage to fetch all the pending unlocks under a operator pool at the time of slashing.
+ */
+export interface DomainsPendingNominatorUnlocksStorageV1 {
+    get(key1: bigint, key2: number): Promise<(v1.PendingNominatorUnlock[] | undefined)>
+    getAll(): Promise<v1.PendingNominatorUnlock[][]>
+    getMany(keys: [bigint, number][]): Promise<(v1.PendingNominatorUnlock[] | undefined)[]>
+    getKeys(): Promise<[bigint, number][]>
+    getKeys(key1: bigint): Promise<[bigint, number][]>
+    getKeys(key1: bigint, key2: number): Promise<[bigint, number][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[bigint, number][]>
+    getKeysPaged(pageSize: number, key1: bigint): AsyncIterable<[bigint, number][]>
+    getKeysPaged(pageSize: number, key1: bigint, key2: number): AsyncIterable<[bigint, number][]>
+    getPairs(): Promise<[k: [bigint, number], v: v1.PendingNominatorUnlock[]][]>
+    getPairs(key1: bigint): Promise<[k: [bigint, number], v: v1.PendingNominatorUnlock[]][]>
+    getPairs(key1: bigint, key2: number): Promise<[k: [bigint, number], v: v1.PendingNominatorUnlock[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [bigint, number], v: v1.PendingNominatorUnlock[]][]>
+    getPairsPaged(pageSize: number, key1: bigint): AsyncIterable<[k: [bigint, number], v: v1.PendingNominatorUnlock[]][]>
+    getPairsPaged(pageSize: number, key1: bigint, key2: number): AsyncIterable<[k: [bigint, number], v: v1.PendingNominatorUnlock[]][]>
+}
+
+export class DomainsPendingOperatorDeregistrationsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingOperatorDeregistrations'
+    }
+
+    /**
+     *  Operators who chose to deregister from a domain.
+     *  Stored here temporarily until domain epoch is complete.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'ad89e1c9cb8fd2d186873c54d677e80653e7a6bb19339657b83b5b789a22279e'
+    }
+
+    /**
+     *  Operators who chose to deregister from a domain.
+     *  Stored here temporarily until domain epoch is complete.
+     */
+    get asV1(): DomainsPendingOperatorDeregistrationsStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Operators who chose to deregister from a domain.
+ *  Stored here temporarily until domain epoch is complete.
+ */
+export interface DomainsPendingOperatorDeregistrationsStorageV1 {
+    get(key: number): Promise<(bigint[] | undefined)>
+    getAll(): Promise<bigint[][]>
+    getMany(keys: number[]): Promise<(bigint[] | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: bigint[]][]>
+    getPairs(key: number): Promise<[k: number, v: bigint[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: bigint[]][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: bigint[]][]>
+}
+
+export class DomainsPendingOperatorSwitchesStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingOperatorSwitches'
+    }
+
+    /**
+     *  Temporary hold of all the operators who decided to switch to another domain.
+     *  Once epoch is complete, these operators are added to new domains under next_operators.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'ad89e1c9cb8fd2d186873c54d677e80653e7a6bb19339657b83b5b789a22279e'
+    }
+
+    /**
+     *  Temporary hold of all the operators who decided to switch to another domain.
+     *  Once epoch is complete, these operators are added to new domains under next_operators.
+     */
+    get asV1(): DomainsPendingOperatorSwitchesStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Temporary hold of all the operators who decided to switch to another domain.
+ *  Once epoch is complete, these operators are added to new domains under next_operators.
+ */
+export interface DomainsPendingOperatorSwitchesStorageV1 {
+    get(key: number): Promise<(bigint[] | undefined)>
+    getAll(): Promise<bigint[][]>
+    getMany(keys: number[]): Promise<(bigint[] | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: bigint[]][]>
+    getPairs(key: number): Promise<[k: number, v: bigint[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: bigint[]][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: bigint[]][]>
+}
+
+export class DomainsPendingOperatorUnlocksStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingOperatorUnlocks'
+    }
+
+    /**
+     *  Stores a list of operators who are unlocking in the coming blocks.
+     *  The operator will be removed when the wait period is over
+     *  or when the operator is slashed.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '6b894cf69a2ca57c425933307e81a0c56377a214575e8ac0ab9ddbe2347b438b'
+    }
+
+    /**
+     *  Stores a list of operators who are unlocking in the coming blocks.
+     *  The operator will be removed when the wait period is over
+     *  or when the operator is slashed.
+     */
+    get asV1(): DomainsPendingOperatorUnlocksStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Stores a list of operators who are unlocking in the coming blocks.
+ *  The operator will be removed when the wait period is over
+ *  or when the operator is slashed.
+ */
+export interface DomainsPendingOperatorUnlocksStorageV1 {
+    get(): Promise<bigint[]>
+}
+
+export class DomainsPendingSlashesStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingSlashes'
+    }
+
+    /**
+     *  A list operators who were slashed during the current epoch associated with the domain.
+     *  When the epoch for a given domain is complete, operator total stake is moved to treasury and
+     *  then deleted.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '8218737ed51b5d9ed164d3a05759476dc1bd11072be34b56804d083471647d25'
+    }
+
+    /**
+     *  A list operators who were slashed during the current epoch associated with the domain.
+     *  When the epoch for a given domain is complete, operator total stake is moved to treasury and
+     *  then deleted.
+     */
+    get asV1(): DomainsPendingSlashesStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  A list operators who were slashed during the current epoch associated with the domain.
+ *  When the epoch for a given domain is complete, operator total stake is moved to treasury and
+ *  then deleted.
+ */
+export interface DomainsPendingSlashesStorageV1 {
+    get(key: number): Promise<([bigint, v1.PendingOperatorSlashInfo][] | undefined)>
+    getAll(): Promise<[bigint, v1.PendingOperatorSlashInfo][][]>
+    getMany(keys: number[]): Promise<([bigint, v1.PendingOperatorSlashInfo][] | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: [bigint, v1.PendingOperatorSlashInfo][]][]>
+    getPairs(key: number): Promise<[k: number, v: [bigint, v1.PendingOperatorSlashInfo][]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: [bigint, v1.PendingOperatorSlashInfo][]][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: [bigint, v1.PendingOperatorSlashInfo][]][]>
+}
+
+export class DomainsPendingStakingOperationCountStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingStakingOperationCount'
+    }
+
+    /**
+     *  The pending staking operation count of the current epoch, it should not larger than
+     *  `MaxPendingStakingOperation` and will be resetted to 0 upon epoch transition.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'be37cd27c0e60862618e14817365ea9f5c3c45854fea63a6259de44af2521364'
+    }
+
+    /**
+     *  The pending staking operation count of the current epoch, it should not larger than
+     *  `MaxPendingStakingOperation` and will be resetted to 0 upon epoch transition.
+     */
+    get asV1(): DomainsPendingStakingOperationCountStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The pending staking operation count of the current epoch, it should not larger than
+ *  `MaxPendingStakingOperation` and will be resetted to 0 upon epoch transition.
+ */
+export interface DomainsPendingStakingOperationCountStorageV1 {
+    get(key: number): Promise<number>
+    getAll(): Promise<number[]>
+    getMany(keys: number[]): Promise<number[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: number][]>
+    getPairs(key: number): Promise<[k: number, v: number][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: number][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: number][]>
+}
+
+export class DomainsPendingUnlocksStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingUnlocks'
+    }
+
+    /**
+     *  A list of operators that are either unregistering or one more of the nominators
+     *  are withdrawing some staked funds.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '990930d6b6298bd986dda49583be2d342dcf5333409e9d4d4ce3dfb872a91d91'
+    }
+
+    /**
+     *  A list of operators that are either unregistering or one more of the nominators
+     *  are withdrawing some staked funds.
+     */
+    get asV1(): DomainsPendingUnlocksStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  A list of operators that are either unregistering or one more of the nominators
+ *  are withdrawing some staked funds.
+ */
+export interface DomainsPendingUnlocksStorageV1 {
+    get(key: [number, number]): Promise<(bigint[] | undefined)>
+    getAll(): Promise<bigint[][]>
+    getMany(keys: [number, number][]): Promise<(bigint[] | undefined)[]>
+    getKeys(): Promise<[number, number][]>
+    getKeys(key: [number, number]): Promise<[number, number][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[number, number][]>
+    getKeysPaged(pageSize: number, key: [number, number]): AsyncIterable<[number, number][]>
+    getPairs(): Promise<[k: [number, number], v: bigint[]][]>
+    getPairs(key: [number, number]): Promise<[k: [number, number], v: bigint[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number], v: bigint[]][]>
+    getPairsPaged(pageSize: number, key: [number, number]): AsyncIterable<[k: [number, number], v: bigint[]][]>
+}
+
+export class DomainsPendingWithdrawalsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PendingWithdrawals'
+    }
+
+    /**
+     *  Withdrawals initiated a nominator under this operator.
+     *  Will be stored temporarily until the current epoch is complete.
+     *  Once, epoch is complete, these will be moved to PendingNominatorUnlocks.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '7c85471fb8d17d4fca6deae963db7106c07030093886a61b90b2d6945733a4d4'
+    }
+
+    /**
+     *  Withdrawals initiated a nominator under this operator.
+     *  Will be stored temporarily until the current epoch is complete.
+     *  Once, epoch is complete, these will be moved to PendingNominatorUnlocks.
+     */
+    get asV1(): DomainsPendingWithdrawalsStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Withdrawals initiated a nominator under this operator.
+ *  Will be stored temporarily until the current epoch is complete.
+ *  Once, epoch is complete, these will be moved to PendingNominatorUnlocks.
+ */
+export interface DomainsPendingWithdrawalsStorageV1 {
+    get(key1: bigint, key2: Uint8Array): Promise<(v1.Withdraw | undefined)>
+    getAll(): Promise<v1.Withdraw[]>
+    getMany(keys: [bigint, Uint8Array][]): Promise<(v1.Withdraw | undefined)[]>
+    getKeys(): Promise<[bigint, Uint8Array][]>
+    getKeys(key1: bigint): Promise<[bigint, Uint8Array][]>
+    getKeys(key1: bigint, key2: Uint8Array): Promise<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number, key1: bigint): AsyncIterable<[bigint, Uint8Array][]>
+    getKeysPaged(pageSize: number, key1: bigint, key2: Uint8Array): AsyncIterable<[bigint, Uint8Array][]>
+    getPairs(): Promise<[k: [bigint, Uint8Array], v: v1.Withdraw][]>
+    getPairs(key1: bigint): Promise<[k: [bigint, Uint8Array], v: v1.Withdraw][]>
+    getPairs(key1: bigint, key2: Uint8Array): Promise<[k: [bigint, Uint8Array], v: v1.Withdraw][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [bigint, Uint8Array], v: v1.Withdraw][]>
+    getPairsPaged(pageSize: number, key1: bigint): AsyncIterable<[k: [bigint, Uint8Array], v: v1.Withdraw][]>
+    getPairsPaged(pageSize: number, key1: bigint, key2: Uint8Array): AsyncIterable<[k: [bigint, Uint8Array], v: v1.Withdraw][]>
+}
+
+export class DomainsPreferredOperatorStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'PreferredOperator'
+    }
+
+    /**
+     *  A preferred Operator for a given Farmer, enabling automatic staking of block rewards.
+     *  For the auto-staking to succeed, the Farmer must also be a Nominator of the preferred Operator.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'fc96d6750297129d4ff884dffc4742fe833e9be687fa34e80679655014942975'
+    }
+
+    /**
+     *  A preferred Operator for a given Farmer, enabling automatic staking of block rewards.
+     *  For the auto-staking to succeed, the Farmer must also be a Nominator of the preferred Operator.
+     */
+    get asV1(): DomainsPreferredOperatorStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  A preferred Operator for a given Farmer, enabling automatic staking of block rewards.
+ *  For the auto-staking to succeed, the Farmer must also be a Nominator of the preferred Operator.
+ */
+export interface DomainsPreferredOperatorStorageV1 {
+    get(key: Uint8Array): Promise<(bigint | undefined)>
+    getAll(): Promise<bigint[]>
+    getMany(keys: Uint8Array[]): Promise<(bigint | undefined)[]>
+    getKeys(): Promise<Uint8Array[]>
+    getKeys(key: Uint8Array): Promise<Uint8Array[]>
+    getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
+    getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
+    getPairs(): Promise<[k: Uint8Array, v: bigint][]>
+    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: bigint][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: bigint][]>
+    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: bigint][]>
+}
+
+export class DomainsRuntimeRegistryStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'RuntimeRegistry'
+    }
+
+    get isV1(): boolean {
+        return this.getTypeHash() === '7cd92574f14ff0421a640a2b24bd26d2f0a6bed95a203e4d4f64136b26c3c3fe'
+    }
+
+    get asV1(): DomainsRuntimeRegistryStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+export interface DomainsRuntimeRegistryStorageV1 {
+    get(key: number): Promise<(v1.RuntimeObject | undefined)>
+    getAll(): Promise<v1.RuntimeObject[]>
+    getMany(keys: number[]): Promise<(v1.RuntimeObject | undefined)[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: v1.RuntimeObject][]>
+    getPairs(key: number): Promise<[k: number, v: v1.RuntimeObject][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: v1.RuntimeObject][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: v1.RuntimeObject][]>
+}
+
+export class DomainsScheduledRuntimeUpgradesStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'ScheduledRuntimeUpgrades'
+    }
+
+    get isV1(): boolean {
+        return this.getTypeHash() === '718ac2b0cf85c498ed81cdf57ca126d62696b0bbd903b1bc92b4a4501dce2ac8'
+    }
+
+    get asV1(): DomainsScheduledRuntimeUpgradesStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+export interface DomainsScheduledRuntimeUpgradesStorageV1 {
+    get(key1: number, key2: number): Promise<(v1.ScheduledRuntimeUpgrade | undefined)>
+    getAll(): Promise<v1.ScheduledRuntimeUpgrade[]>
+    getMany(keys: [number, number][]): Promise<(v1.ScheduledRuntimeUpgrade | undefined)[]>
+    getKeys(): Promise<[number, number][]>
+    getKeys(key1: number): Promise<[number, number][]>
+    getKeys(key1: number, key2: number): Promise<[number, number][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[number, number][]>
+    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, number][]>
+    getKeysPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[number, number][]>
+    getPairs(): Promise<[k: [number, number], v: v1.ScheduledRuntimeUpgrade][]>
+    getPairs(key1: number): Promise<[k: [number, number], v: v1.ScheduledRuntimeUpgrade][]>
+    getPairs(key1: number, key2: number): Promise<[k: [number, number], v: v1.ScheduledRuntimeUpgrade][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number], v: v1.ScheduledRuntimeUpgrade][]>
+    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, number], v: v1.ScheduledRuntimeUpgrade][]>
+    getPairsPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[k: [number, number], v: v1.ScheduledRuntimeUpgrade][]>
+}
+
+export class DomainsStateRootsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'StateRoots'
+    }
+
+    /**
+     *  State root mapped again each domain (block, hash)
+     *  This acts as an index for other protocols like XDM to fetch state roots faster.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === '761cba00429d11332c16c4e8e73c5d48f26da7ac2b15449cb5c7d04591eb59e2'
+    }
+
+    /**
+     *  State root mapped again each domain (block, hash)
+     *  This acts as an index for other protocols like XDM to fetch state roots faster.
+     */
+    get asV1(): DomainsStateRootsStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  State root mapped again each domain (block, hash)
+ *  This acts as an index for other protocols like XDM to fetch state roots faster.
+ */
+export interface DomainsStateRootsStorageV1 {
+    get(key: [number, number, Uint8Array]): Promise<(Uint8Array | undefined)>
+    getAll(): Promise<Uint8Array[]>
+    getMany(keys: [number, number, Uint8Array][]): Promise<(Uint8Array | undefined)[]>
+    getKeys(): Promise<[number, number, Uint8Array][]>
+    getKeys(key: [number, number, Uint8Array]): Promise<[number, number, Uint8Array][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[number, number, Uint8Array][]>
+    getKeysPaged(pageSize: number, key: [number, number, Uint8Array]): AsyncIterable<[number, number, Uint8Array][]>
+    getPairs(): Promise<[k: [number, number, Uint8Array], v: Uint8Array][]>
+    getPairs(key: [number, number, Uint8Array]): Promise<[k: [number, number, Uint8Array], v: Uint8Array][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number, Uint8Array], v: Uint8Array][]>
+    getPairsPaged(pageSize: number, key: [number, number, Uint8Array]): AsyncIterable<[k: [number, number, Uint8Array], v: Uint8Array][]>
+}
+
+export class DomainsSuccessfulBundlesStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Domains'
+    }
+
+    protected getName() {
+        return 'SuccessfulBundles'
+    }
+
+    /**
+     *  Bundles submitted successfully in current block.
+     */
+    get isV1(): boolean {
+        return this.getTypeHash() === 'f619540cfd39ec62194ccd8c2d0c1c6ffcb39cfc17df25d0e83357e4b6c7d6d5'
+    }
+
+    /**
+     *  Bundles submitted successfully in current block.
+     */
+    get asV1(): DomainsSuccessfulBundlesStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Bundles submitted successfully in current block.
+ */
+export interface DomainsSuccessfulBundlesStorageV1 {
+    get(key: number): Promise<Uint8Array[]>
+    getAll(): Promise<Uint8Array[][]>
+    getMany(keys: number[]): Promise<Uint8Array[][]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: Uint8Array[]][]>
+    getPairs(key: number): Promise<[k: number, v: Uint8Array[]][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: Uint8Array[]][]>
+    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: Uint8Array[]][]>
 }
 
 export class FeedsFeedConfigsStorage extends StorageBase {
@@ -941,324 +2217,6 @@ export interface OffencesSubspaceReportsByKindIndexStorageV1 {
     getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: Uint8Array][]>
 }
 
-export class ReceiptsHeadReceiptNumberStorage extends StorageBase {
-    protected getPrefix() {
-        return 'Receipts'
-    }
-
-    protected getName() {
-        return 'HeadReceiptNumber'
-    }
-
-    /**
-     *  Stores the latest block number for which Execution receipt(s) are available for a given Domain.
-     */
-    get isV1(): boolean {
-        return this.getTypeHash() === 'be37cd27c0e60862618e14817365ea9f5c3c45854fea63a6259de44af2521364'
-    }
-
-    /**
-     *  Stores the latest block number for which Execution receipt(s) are available for a given Domain.
-     */
-    get asV1(): ReceiptsHeadReceiptNumberStorageV1 {
-        assert(this.isV1)
-        return this as any
-    }
-}
-
-/**
- *  Stores the latest block number for which Execution receipt(s) are available for a given Domain.
- */
-export interface ReceiptsHeadReceiptNumberStorageV1 {
-    get(key: number): Promise<number>
-    getAll(): Promise<number[]>
-    getMany(keys: number[]): Promise<number[]>
-    getKeys(): Promise<number[]>
-    getKeys(key: number): Promise<number[]>
-    getKeysPaged(pageSize: number): AsyncIterable<number[]>
-    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
-    getPairs(): Promise<[k: number, v: number][]>
-    getPairs(key: number): Promise<[k: number, v: number][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: number][]>
-    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: number][]>
-}
-
-export class ReceiptsOldestReceiptNumberStorage extends StorageBase {
-    protected getPrefix() {
-        return 'Receipts'
-    }
-
-    protected getName() {
-        return 'OldestReceiptNumber'
-    }
-
-    /**
-     *  Block number of the oldest receipt stored in the state.
-     */
-    get isV1(): boolean {
-        return this.getTypeHash() === 'be37cd27c0e60862618e14817365ea9f5c3c45854fea63a6259de44af2521364'
-    }
-
-    /**
-     *  Block number of the oldest receipt stored in the state.
-     */
-    get asV1(): ReceiptsOldestReceiptNumberStorageV1 {
-        assert(this.isV1)
-        return this as any
-    }
-}
-
-/**
- *  Block number of the oldest receipt stored in the state.
- */
-export interface ReceiptsOldestReceiptNumberStorageV1 {
-    get(key: number): Promise<number>
-    getAll(): Promise<number[]>
-    getMany(keys: number[]): Promise<number[]>
-    getKeys(): Promise<number[]>
-    getKeys(key: number): Promise<number[]>
-    getKeysPaged(pageSize: number): AsyncIterable<number[]>
-    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
-    getPairs(): Promise<[k: number, v: number][]>
-    getPairs(key: number): Promise<[k: number, v: number][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: number][]>
-    getPairsPaged(pageSize: number, key: number): AsyncIterable<[k: number, v: number][]>
-}
-
-export class ReceiptsPrimaryBlockHashStorage extends StorageBase {
-    protected getPrefix() {
-        return 'Receipts'
-    }
-
-    protected getName() {
-        return 'PrimaryBlockHash'
-    }
-
-    /**
-     *  Map of primary block number to primary block hash for tracking bounded receipts per domain.
-     * 
-     *  The oldest block hash will be pruned once the oldest receipt is pruned. However, if a
-     *  domain stalls, i.e., no receipts are included in the domain's parent chain for a long time,
-     *  the corresponding entry will grow indefinitely.
-     * 
-     *  TODO: there is a pitfall that any stalled domain can lead to an ubounded runtime storage
-     *  growth.
-     */
-    get isV1(): boolean {
-        return this.getTypeHash() === 'b3c15232fb4346b458fc3153a06d89787a103676fa34fe3d795ee04fe62bf4d8'
-    }
-
-    /**
-     *  Map of primary block number to primary block hash for tracking bounded receipts per domain.
-     * 
-     *  The oldest block hash will be pruned once the oldest receipt is pruned. However, if a
-     *  domain stalls, i.e., no receipts are included in the domain's parent chain for a long time,
-     *  the corresponding entry will grow indefinitely.
-     * 
-     *  TODO: there is a pitfall that any stalled domain can lead to an ubounded runtime storage
-     *  growth.
-     */
-    get asV1(): ReceiptsPrimaryBlockHashStorageV1 {
-        assert(this.isV1)
-        return this as any
-    }
-}
-
-/**
- *  Map of primary block number to primary block hash for tracking bounded receipts per domain.
- * 
- *  The oldest block hash will be pruned once the oldest receipt is pruned. However, if a
- *  domain stalls, i.e., no receipts are included in the domain's parent chain for a long time,
- *  the corresponding entry will grow indefinitely.
- * 
- *  TODO: there is a pitfall that any stalled domain can lead to an ubounded runtime storage
- *  growth.
- */
-export interface ReceiptsPrimaryBlockHashStorageV1 {
-    get(key1: number, key2: number): Promise<(Uint8Array | undefined)>
-    getAll(): Promise<Uint8Array[]>
-    getMany(keys: [number, number][]): Promise<(Uint8Array | undefined)[]>
-    getKeys(): Promise<[number, number][]>
-    getKeys(key1: number): Promise<[number, number][]>
-    getKeys(key1: number, key2: number): Promise<[number, number][]>
-    getKeysPaged(pageSize: number): AsyncIterable<[number, number][]>
-    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, number][]>
-    getKeysPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[number, number][]>
-    getPairs(): Promise<[k: [number, number], v: Uint8Array][]>
-    getPairs(key1: number): Promise<[k: [number, number], v: Uint8Array][]>
-    getPairs(key1: number, key2: number): Promise<[k: [number, number], v: Uint8Array][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number], v: Uint8Array][]>
-    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, number], v: Uint8Array][]>
-    getPairsPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[k: [number, number], v: Uint8Array][]>
-}
-
-export class ReceiptsReceiptVotesStorage extends StorageBase {
-    protected getPrefix() {
-        return 'Receipts'
-    }
-
-    protected getName() {
-        return 'ReceiptVotes'
-    }
-
-    /**
-     *  Mapping for tracking the receipt votes.
-     * 
-     *  (domain_id, domain_block_hash, receipt_hash) -> receipt_count
-     */
-    get isV1(): boolean {
-        return this.getTypeHash() === 'b5368aba2b08a0cd7eb0f2a07079ff53382c43f521633e8200f78bd0032c5b91'
-    }
-
-    /**
-     *  Mapping for tracking the receipt votes.
-     * 
-     *  (domain_id, domain_block_hash, receipt_hash) -> receipt_count
-     */
-    get asV1(): ReceiptsReceiptVotesStorageV1 {
-        assert(this.isV1)
-        return this as any
-    }
-}
-
-/**
- *  Mapping for tracking the receipt votes.
- * 
- *  (domain_id, domain_block_hash, receipt_hash) -> receipt_count
- */
-export interface ReceiptsReceiptVotesStorageV1 {
-    get(key1: number, key2: Uint8Array, key3: Uint8Array): Promise<number>
-    getAll(): Promise<number[]>
-    getMany(keys: [number, Uint8Array, Uint8Array][]): Promise<number[]>
-    getKeys(): Promise<[number, Uint8Array, Uint8Array][]>
-    getKeys(key1: number): Promise<[number, Uint8Array, Uint8Array][]>
-    getKeys(key1: number, key2: Uint8Array): Promise<[number, Uint8Array, Uint8Array][]>
-    getKeys(key1: number, key2: Uint8Array, key3: Uint8Array): Promise<[number, Uint8Array, Uint8Array][]>
-    getKeysPaged(pageSize: number): AsyncIterable<[number, Uint8Array, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, Uint8Array, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number, key2: Uint8Array): AsyncIterable<[number, Uint8Array, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number, key2: Uint8Array, key3: Uint8Array): AsyncIterable<[number, Uint8Array, Uint8Array][]>
-    getPairs(): Promise<[k: [number, Uint8Array, Uint8Array], v: number][]>
-    getPairs(key1: number): Promise<[k: [number, Uint8Array, Uint8Array], v: number][]>
-    getPairs(key1: number, key2: Uint8Array): Promise<[k: [number, Uint8Array, Uint8Array], v: number][]>
-    getPairs(key1: number, key2: Uint8Array, key3: Uint8Array): Promise<[k: [number, Uint8Array, Uint8Array], v: number][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, Uint8Array, Uint8Array], v: number][]>
-    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, Uint8Array, Uint8Array], v: number][]>
-    getPairsPaged(pageSize: number, key1: number, key2: Uint8Array): AsyncIterable<[k: [number, Uint8Array, Uint8Array], v: number][]>
-    getPairsPaged(pageSize: number, key1: number, key2: Uint8Array, key3: Uint8Array): AsyncIterable<[k: [number, Uint8Array, Uint8Array], v: number][]>
-}
-
-export class ReceiptsReceiptsStorage extends StorageBase {
-    protected getPrefix() {
-        return 'Receipts'
-    }
-
-    protected getName() {
-        return 'Receipts'
-    }
-
-    /**
-     *  Mapping from the receipt hash to the corresponding verified execution receipt.
-     * 
-     *  The capacity of receipts stored in the state is [`Config::ReceiptsPruningDepth`], the older
-     *  ones will be pruned once the size of receipts exceeds this number.
-     */
-    get isV1(): boolean {
-        return this.getTypeHash() === 'c2881848fa0c99d217c29d7d90870276b0ab8167a6029df9c77ee92d7838790d'
-    }
-
-    /**
-     *  Mapping from the receipt hash to the corresponding verified execution receipt.
-     * 
-     *  The capacity of receipts stored in the state is [`Config::ReceiptsPruningDepth`], the older
-     *  ones will be pruned once the size of receipts exceeds this number.
-     */
-    get asV1(): ReceiptsReceiptsStorageV1 {
-        assert(this.isV1)
-        return this as any
-    }
-}
-
-/**
- *  Mapping from the receipt hash to the corresponding verified execution receipt.
- * 
- *  The capacity of receipts stored in the state is [`Config::ReceiptsPruningDepth`], the older
- *  ones will be pruned once the size of receipts exceeds this number.
- */
-export interface ReceiptsReceiptsStorageV1 {
-    get(key1: number, key2: Uint8Array): Promise<(v1.ExecutionReceipt | undefined)>
-    getAll(): Promise<v1.ExecutionReceipt[]>
-    getMany(keys: [number, Uint8Array][]): Promise<(v1.ExecutionReceipt | undefined)[]>
-    getKeys(): Promise<[number, Uint8Array][]>
-    getKeys(key1: number): Promise<[number, Uint8Array][]>
-    getKeys(key1: number, key2: Uint8Array): Promise<[number, Uint8Array][]>
-    getKeysPaged(pageSize: number): AsyncIterable<[number, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number, key2: Uint8Array): AsyncIterable<[number, Uint8Array][]>
-    getPairs(): Promise<[k: [number, Uint8Array], v: v1.ExecutionReceipt][]>
-    getPairs(key1: number): Promise<[k: [number, Uint8Array], v: v1.ExecutionReceipt][]>
-    getPairs(key1: number, key2: Uint8Array): Promise<[k: [number, Uint8Array], v: v1.ExecutionReceipt][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, Uint8Array], v: v1.ExecutionReceipt][]>
-    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, Uint8Array], v: v1.ExecutionReceipt][]>
-    getPairsPaged(pageSize: number, key1: number, key2: Uint8Array): AsyncIterable<[k: [number, Uint8Array], v: v1.ExecutionReceipt][]>
-}
-
-export class ReceiptsStateRootsStorage extends StorageBase {
-    protected getPrefix() {
-        return 'Receipts'
-    }
-
-    protected getName() {
-        return 'StateRoots'
-    }
-
-    /**
-     *  Mapping for tracking the domain state roots.
-     * 
-     *  (domain_id, domain_block_number, domain_block_hash) -> domain_state_root
-     */
-    get isV1(): boolean {
-        return this.getTypeHash() === 'af09af2e541e67c95622fd28dbdbad7b90d885c7e03a2cbf4412f369450db480'
-    }
-
-    /**
-     *  Mapping for tracking the domain state roots.
-     * 
-     *  (domain_id, domain_block_number, domain_block_hash) -> domain_state_root
-     */
-    get asV1(): ReceiptsStateRootsStorageV1 {
-        assert(this.isV1)
-        return this as any
-    }
-}
-
-/**
- *  Mapping for tracking the domain state roots.
- * 
- *  (domain_id, domain_block_number, domain_block_hash) -> domain_state_root
- */
-export interface ReceiptsStateRootsStorageV1 {
-    get(key1: number, key2: number, key3: Uint8Array): Promise<(Uint8Array | undefined)>
-    getAll(): Promise<Uint8Array[]>
-    getMany(keys: [number, number, Uint8Array][]): Promise<(Uint8Array | undefined)[]>
-    getKeys(): Promise<[number, number, Uint8Array][]>
-    getKeys(key1: number): Promise<[number, number, Uint8Array][]>
-    getKeys(key1: number, key2: number): Promise<[number, number, Uint8Array][]>
-    getKeys(key1: number, key2: number, key3: Uint8Array): Promise<[number, number, Uint8Array][]>
-    getKeysPaged(pageSize: number): AsyncIterable<[number, number, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number): AsyncIterable<[number, number, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[number, number, Uint8Array][]>
-    getKeysPaged(pageSize: number, key1: number, key2: number, key3: Uint8Array): AsyncIterable<[number, number, Uint8Array][]>
-    getPairs(): Promise<[k: [number, number, Uint8Array], v: Uint8Array][]>
-    getPairs(key1: number): Promise<[k: [number, number, Uint8Array], v: Uint8Array][]>
-    getPairs(key1: number, key2: number): Promise<[k: [number, number, Uint8Array], v: Uint8Array][]>
-    getPairs(key1: number, key2: number, key3: Uint8Array): Promise<[k: [number, number, Uint8Array], v: Uint8Array][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: [number, number, Uint8Array], v: Uint8Array][]>
-    getPairsPaged(pageSize: number, key1: number): AsyncIterable<[k: [number, number, Uint8Array], v: Uint8Array][]>
-    getPairsPaged(pageSize: number, key1: number, key2: number): AsyncIterable<[k: [number, number, Uint8Array], v: Uint8Array][]>
-    getPairsPaged(pageSize: number, key1: number, key2: number, key3: Uint8Array): AsyncIterable<[k: [number, number, Uint8Array], v: Uint8Array][]>
-}
-
 export class RuntimeConfigsConfirmationDepthKStorage extends StorageBase {
     protected getPrefix() {
         return 'RuntimeConfigs'
@@ -1282,35 +2240,35 @@ export interface RuntimeConfigsConfirmationDepthKStorageV1 {
     get(): Promise<number>
 }
 
-export class RuntimeConfigsEnableExecutorStorage extends StorageBase {
+export class RuntimeConfigsEnableDomainsStorage extends StorageBase {
     protected getPrefix() {
         return 'RuntimeConfigs'
     }
 
     protected getName() {
-        return 'EnableExecutor'
+        return 'EnableDomains'
     }
 
     /**
-     *  Whether to disable the executor calls.
+     *  Whether to disable the calls in pallet-domains.
      */
     get isV1(): boolean {
         return this.getTypeHash() === '1b6fbf1674d189f761a7ac63093bf5c755bf073dd9d9f0dbe657289f92575db5'
     }
 
     /**
-     *  Whether to disable the executor calls.
+     *  Whether to disable the calls in pallet-domains.
      */
-    get asV1(): RuntimeConfigsEnableExecutorStorageV1 {
+    get asV1(): RuntimeConfigsEnableDomainsStorageV1 {
         assert(this.isV1)
         return this as any
     }
 }
 
 /**
- *  Whether to disable the executor calls.
+ *  Whether to disable the calls in pallet-domains.
  */
-export interface RuntimeConfigsEnableExecutorStorageV1 {
+export interface RuntimeConfigsEnableDomainsStorageV1 {
     get(): Promise<boolean>
 }
 
@@ -1465,7 +2423,7 @@ export class SubspaceCurrentBlockAuthorInfoStorage extends StorageBase {
      *  Temporary value (cleared at block finalization) with block author information.
      */
     get isV1(): boolean {
-        return this.getTypeHash() === '6d79390637ae1a4b2c7f94365fac773058faad0c5c3975e0c9f890274124be78'
+        return this.getTypeHash() === '61c86c54648077a98a979d6aa8f50e42a3c15039790d738c6510cad634bd97a1'
     }
 
     /**
@@ -1481,7 +2439,7 @@ export class SubspaceCurrentBlockAuthorInfoStorage extends StorageBase {
  *  Temporary value (cleared at block finalization) with block author information.
  */
 export interface SubspaceCurrentBlockAuthorInfoStorageV1 {
-    get(): Promise<([Uint8Array, bigint, number, bigint, Uint8Array] | undefined)>
+    get(): Promise<([Uint8Array, number, v1.Scalar, number, bigint, Uint8Array] | undefined)>
 }
 
 export class SubspaceCurrentBlockVotersStorage extends StorageBase {
@@ -1497,7 +2455,7 @@ export class SubspaceCurrentBlockVotersStorage extends StorageBase {
      *  Temporary value (cleared at block finalization) with voters in the current block thus far.
      */
     get isV1(): boolean {
-        return this.getTypeHash() === '47def9f6d7e6014a6300f058be0c10695977357e2d30d053338f97ef5e29b57c'
+        return this.getTypeHash() === '16936fb9f93b37c7d70eb7b0853a969b58a8e69eb34525b13fd91991420cbe5b'
     }
 
     /**
@@ -1513,7 +2471,7 @@ export class SubspaceCurrentBlockVotersStorage extends StorageBase {
  *  Temporary value (cleared at block finalization) with voters in the current block thus far.
  */
 export interface SubspaceCurrentBlockVotersStorageV1 {
-    get(): Promise<([[Uint8Array, bigint, number, bigint], [Uint8Array, Uint8Array]][] | undefined)>
+    get(): Promise<([[Uint8Array, number, v1.Scalar, number, bigint], [Uint8Array, Uint8Array]][] | undefined)>
 }
 
 export class SubspaceCurrentSlotStorage extends StorageBase {
@@ -1753,7 +2711,7 @@ export class SubspaceParentBlockAuthorInfoStorage extends StorageBase {
      *  Parent block author information.
      */
     get isV1(): boolean {
-        return this.getTypeHash() === 'ba9fc0896f843bdd462fb296fc28c5b777440427dcb2d8ddc4df69e77a826901'
+        return this.getTypeHash() === 'edfb0faf0a6f0a122e754cc01f777b1d00ca2d371a525af68d489ebb60c07ff7'
     }
 
     /**
@@ -1769,7 +2727,7 @@ export class SubspaceParentBlockAuthorInfoStorage extends StorageBase {
  *  Parent block author information.
  */
 export interface SubspaceParentBlockAuthorInfoStorageV1 {
-    get(): Promise<([Uint8Array, bigint, number, bigint] | undefined)>
+    get(): Promise<([Uint8Array, number, v1.Scalar, number, bigint] | undefined)>
 }
 
 export class SubspaceParentBlockVotersStorage extends StorageBase {
@@ -1785,7 +2743,7 @@ export class SubspaceParentBlockVotersStorage extends StorageBase {
      *  Voters in the parent block (set at the end of the block with current values).
      */
     get isV1(): boolean {
-        return this.getTypeHash() === '40d56fe1f1fa7e5a7a12eca51129efa2535e4ea87c718b94396215bf1e0da8c1'
+        return this.getTypeHash() === 'ea9fce3ce021125c045cd2696e1a8c2c8c14473c840b010b480a31672969db42'
     }
 
     /**
@@ -1801,7 +2759,7 @@ export class SubspaceParentBlockVotersStorage extends StorageBase {
  *  Voters in the parent block (set at the end of the block with current values).
  */
 export interface SubspaceParentBlockVotersStorageV1 {
-    get(): Promise<[[Uint8Array, bigint, number, bigint], [Uint8Array, Uint8Array]][]>
+    get(): Promise<[[Uint8Array, number, v1.Scalar, number, bigint], [Uint8Array, Uint8Array]][]>
 }
 
 export class SubspaceParentVoteVerificationDataStorage extends StorageBase {
@@ -2057,7 +3015,7 @@ export class SystemAccountStorage extends StorageBase {
      *  The full account information for a particular account ID.
      */
     get isV1(): boolean {
-        return this.getTypeHash() === '1ddc7ade926221442c388ee4405a71c9428e548fab037445aaf4b3a78f4735c1'
+        return this.getTypeHash() === 'd6b7a816e0cf6dc8f60cb2bd55c5c5ae7ad928521a6e98aafbe6e954f5c54878'
     }
 
     /**
@@ -2065,21 +3023,6 @@ export class SystemAccountStorage extends StorageBase {
      */
     get asV1(): SystemAccountStorageV1 {
         assert(this.isV1)
-        return this as any
-    }
-
-    /**
-     *  The full account information for a particular account ID.
-     */
-    get isV2(): boolean {
-        return this.getTypeHash() === 'd6b7a816e0cf6dc8f60cb2bd55c5c5ae7ad928521a6e98aafbe6e954f5c54878'
-    }
-
-    /**
-     *  The full account information for a particular account ID.
-     */
-    get asV2(): SystemAccountStorageV2 {
-        assert(this.isV2)
         return this as any
     }
 }
@@ -2099,23 +3042,6 @@ export interface SystemAccountStorageV1 {
     getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v1.AccountInfo][]>
     getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v1.AccountInfo][]>
     getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v1.AccountInfo][]>
-}
-
-/**
- *  The full account information for a particular account ID.
- */
-export interface SystemAccountStorageV2 {
-    get(key: Uint8Array): Promise<v2.AccountInfo>
-    getAll(): Promise<v2.AccountInfo[]>
-    getMany(keys: Uint8Array[]): Promise<v2.AccountInfo[]>
-    getKeys(): Promise<Uint8Array[]>
-    getKeys(key: Uint8Array): Promise<Uint8Array[]>
-    getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
-    getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
-    getPairs(): Promise<[k: Uint8Array, v: v2.AccountInfo][]>
-    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v2.AccountInfo][]>
-    getPairsPaged(pageSize: number): AsyncIterable<[k: Uint8Array, v: v2.AccountInfo][]>
-    getPairsPaged(pageSize: number, key: Uint8Array): AsyncIterable<[k: Uint8Array, v: v2.AccountInfo][]>
 }
 
 export class SystemAllExtrinsicsLenStorage extends StorageBase {
@@ -2376,7 +3302,7 @@ export class SystemEventsStorage extends StorageBase {
      *  just in case someone still reads them from within the runtime.
      */
     get isV1(): boolean {
-        return this.getTypeHash() === 'c7542c22fedb6c5b96d0a6a5c06a5d090f70a3c3f4624f63e2fad03a5f014c42'
+        return this.getTypeHash() === '8f37e440db51b1813f5235d6e60d46154006ae9e3e8cfca47d947c7071724c04'
     }
 
     /**
@@ -2392,33 +3318,6 @@ export class SystemEventsStorage extends StorageBase {
         assert(this.isV1)
         return this as any
     }
-
-    /**
-     *  Events deposited for the current block.
-     * 
-     *  NOTE: The item is unbound and should therefore never be read on chain.
-     *  It could otherwise inflate the PoV size of a block.
-     * 
-     *  Events have a large in-memory size. Box the events to not go out-of-memory
-     *  just in case someone still reads them from within the runtime.
-     */
-    get isV2(): boolean {
-        return this.getTypeHash() === 'e04e990fca9a753e1b532372cc7a4641d9bfdb9fbfe71b83a569f84c209a0631'
-    }
-
-    /**
-     *  Events deposited for the current block.
-     * 
-     *  NOTE: The item is unbound and should therefore never be read on chain.
-     *  It could otherwise inflate the PoV size of a block.
-     * 
-     *  Events have a large in-memory size. Box the events to not go out-of-memory
-     *  just in case someone still reads them from within the runtime.
-     */
-    get asV2(): SystemEventsStorageV2 {
-        assert(this.isV2)
-        return this as any
-    }
 }
 
 /**
@@ -2432,19 +3331,6 @@ export class SystemEventsStorage extends StorageBase {
  */
 export interface SystemEventsStorageV1 {
     get(): Promise<v1.EventRecord[]>
-}
-
-/**
- *  Events deposited for the current block.
- * 
- *  NOTE: The item is unbound and should therefore never be read on chain.
- *  It could otherwise inflate the PoV size of a block.
- * 
- *  Events have a large in-memory size. Box the events to not go out-of-memory
- *  just in case someone still reads them from within the runtime.
- */
-export interface SystemEventsStorageV2 {
-    get(): Promise<v2.EventRecord[]>
 }
 
 export class SystemExecutionPhaseStorage extends StorageBase {
@@ -2978,7 +3864,7 @@ export class VestingVestingSchedulesStorage extends StorageBase {
     /**
      *  Vesting schedules of an account.
      * 
-     *  VestingSchedules: map AccountId => Vec\<VestingSchedule>
+     *  VestingSchedules: map AccountId => Vec<VestingSchedule>
      */
     get isV1(): boolean {
         return this.getTypeHash() === 'd1025301ffa60f04c50bb1007ecb356d52103dd9c366150de1ba80c6e043ac2f'
@@ -2987,7 +3873,7 @@ export class VestingVestingSchedulesStorage extends StorageBase {
     /**
      *  Vesting schedules of an account.
      * 
-     *  VestingSchedules: map AccountId => Vec\<VestingSchedule>
+     *  VestingSchedules: map AccountId => Vec<VestingSchedule>
      */
     get asV1(): VestingVestingSchedulesStorageV1 {
         assert(this.isV1)
@@ -2998,7 +3884,7 @@ export class VestingVestingSchedulesStorage extends StorageBase {
 /**
  *  Vesting schedules of an account.
  * 
- *  VestingSchedules: map AccountId => Vec\<VestingSchedule>
+ *  VestingSchedules: map AccountId => Vec<VestingSchedule>
  */
 export interface VestingVestingSchedulesStorageV1 {
     get(key: Uint8Array): Promise<v1.VestingSchedule[]>

--- a/squid-blockexplorer/src/types/v1.ts
+++ b/squid-blockexplorer/src/types/v1.ts
@@ -10,6 +10,12 @@ export interface BalanceStatus_Reserved {
     __kind: 'Reserved'
 }
 
+export type RuntimeType = RuntimeType_Evm
+
+export interface RuntimeType_Evm {
+    __kind: 'Evm'
+}
+
 export type SegmentHeader = SegmentHeader_V0
 
 export interface SegmentHeader_V0 {
@@ -20,18 +26,18 @@ export interface SegmentHeader_V0 {
     lastArchivedBlock: LastArchivedBlock
 }
 
-export type Type_46 = Type_46_Ok | Type_46_Err
+export type Type_47 = Type_47_Ok | Type_47_Err
 
-export interface Type_46_Ok {
+export interface Type_47_Ok {
     __kind: 'Ok'
 }
 
-export interface Type_46_Err {
+export interface Type_47_Err {
     __kind: 'Err'
     value: DispatchError
 }
 
-export type DispatchError = DispatchError_Other | DispatchError_CannotLookup | DispatchError_BadOrigin | DispatchError_Module | DispatchError_ConsumerRemaining | DispatchError_NoProviders | DispatchError_TooManyConsumers | DispatchError_Token | DispatchError_Arithmetic | DispatchError_Transactional | DispatchError_Exhausted | DispatchError_Corruption | DispatchError_Unavailable
+export type DispatchError = DispatchError_Other | DispatchError_CannotLookup | DispatchError_BadOrigin | DispatchError_Module | DispatchError_ConsumerRemaining | DispatchError_NoProviders | DispatchError_TooManyConsumers | DispatchError_Token | DispatchError_Arithmetic | DispatchError_Transactional | DispatchError_Exhausted | DispatchError_Corruption | DispatchError_Unavailable | DispatchError_RootNotAllowed
 
 export interface DispatchError_Other {
     __kind: 'Other'
@@ -89,6 +95,10 @@ export interface DispatchError_Unavailable {
     __kind: 'Unavailable'
 }
 
+export interface DispatchError_RootNotAllowed {
+    __kind: 'RootNotAllowed'
+}
+
 export interface DispatchInfo {
     weight: Weight
     class: DispatchClass
@@ -129,18 +139,24 @@ export interface MultiAddress_Address20 {
     value: Uint8Array
 }
 
-export interface SignedBundle {
-    bundle: Bundle
-    bundleSolution: BundleSolution
-    signature: Uint8Array
+export interface DomainConfig {
+    domainName: Uint8Array
+    runtimeId: number
+    maxBlockSize: number
+    maxBlockWeight: Weight
+    bundleSlotProbability: [bigint, bigint]
+    targetBundlesPerBlock: number
 }
 
-export interface BundleEquivocationProof {
-    domainId: number
-    offender: Uint8Array
-    slot: bigint
-    firstHeader: BundleHeader
-    secondHeader: BundleHeader
+export interface OperatorConfig {
+    signingKey: Uint8Array
+    minimumNominatorStake: bigint
+    nominationTax: number
+}
+
+export interface Bundle {
+    sealedHeader: SealedBundleHeader
+    extrinsics: Uint8Array[]
 }
 
 export type FraudProof = FraudProof_InvalidStateTransition | FraudProof_InvalidTransaction | FraudProof_BundleEquivocation | FraudProof_ImproperTransactionSortition
@@ -165,8 +181,15 @@ export interface FraudProof_ImproperTransactionSortition {
     value: ImproperTransactionSortitionProof
 }
 
-export interface InvalidTransactionProof {
-    domainId: number
+export type Withdraw = Withdraw_All | Withdraw_Some
+
+export interface Withdraw_All {
+    __kind: 'All'
+}
+
+export interface Withdraw_Some {
+    __kind: 'Some'
+    value: bigint
 }
 
 export type FeedProcessorKind = FeedProcessorKind_ContentAddressable | FeedProcessorKind_PolkadotLike | FeedProcessorKind_ParachainLike
@@ -267,8 +290,17 @@ export interface OriginCaller_Void {
 export interface AccountData {
     free: bigint
     reserved: bigint
-    miscFrozen: bigint
-    feeFrozen: bigint
+    frozen: bigint
+    flags: bigint
+}
+
+export interface Type_139 {
+    amount: bigint
+}
+
+export interface IdAmount {
+    id: HoldIdentifier
+    amount: bigint
 }
 
 export interface BalanceLock {
@@ -280,6 +312,101 @@ export interface BalanceLock {
 export interface ReserveData {
     id: Uint8Array
     amount: bigint
+}
+
+export interface DomainBlock {
+    executionReceipt: ExecutionReceipt
+    operatorIds: bigint[]
+}
+
+export interface DomainObject {
+    ownerAccountId: Uint8Array
+    createdAt: number
+    genesisReceiptHash: Uint8Array
+    domainConfig: DomainConfig
+    rawGenesisConfig: (Uint8Array | undefined)
+}
+
+export interface StakingSummary {
+    currentEpochIndex: number
+    currentTotalStake: bigint
+    currentOperators: [bigint, bigint][]
+    nextOperators: bigint[]
+    currentEpochRewards: [bigint, bigint][]
+}
+
+export interface TxRangeState {
+    txRange: bigint
+    intervalBlocks: bigint
+    intervalBundles: bigint
+}
+
+export interface BundleDigest {
+    headerHash: Uint8Array
+    extrinsicsRoot: Uint8Array
+}
+
+export interface ElectionVerificationParams {
+    operators: [bigint, bigint][]
+    totalDomainStake: bigint
+}
+
+export interface Nominator {
+    shares: bigint
+}
+
+export interface Operator {
+    signingKey: Uint8Array
+    currentDomainId: number
+    nextDomainId: number
+    minimumNominatorStake: bigint
+    nominationTax: number
+    currentTotalStake: bigint
+    currentEpochRewards: bigint
+    totalShares: bigint
+    status: OperatorStatus
+}
+
+export interface GenesisDomain {
+    runtimeName: Uint8Array
+    runtimeType: RuntimeType
+    runtimeVersion: RuntimeVersion
+    code: Uint8Array
+    ownerAccountId: Uint8Array
+    domainName: Uint8Array
+    maxBlockSize: number
+    maxBlockWeight: Weight
+    bundleSlotProbability: [bigint, bigint]
+    targetBundlesPerBlock: number
+    rawGenesisConfig: Uint8Array
+    signingKey: Uint8Array
+    minimumNominatorStake: bigint
+    nominationTax: number
+}
+
+export interface PendingNominatorUnlock {
+    nominatorId: Uint8Array
+    balance: bigint
+}
+
+export interface PendingOperatorSlashInfo {
+    unlockingNominators: PendingNominatorUnlock[]
+}
+
+export interface RuntimeObject {
+    runtimeName: Uint8Array
+    runtimeType: RuntimeType
+    runtimeUpgrades: number
+    hash: Uint8Array
+    code: Uint8Array
+    version: RuntimeVersion
+    createdAt: number
+    updatedAt: number
+}
+
+export interface ScheduledRuntimeUpgrade {
+    code: Uint8Array
+    version: RuntimeVersion
 }
 
 export interface FeedConfig {
@@ -302,12 +429,8 @@ export interface OffenceDetails {
     offender: Uint8Array
 }
 
-export interface ExecutionReceipt {
-    primaryNumber: number
-    primaryHash: Uint8Array
-    domainHash: Uint8Array
-    trace: Uint8Array[]
-    traceRoot: Uint8Array
+export interface Scalar {
+    inner: Uint8Array
 }
 
 export interface GlobalRandomnesses {
@@ -434,14 +557,14 @@ export interface ModuleError {
     error: Uint8Array
 }
 
-export type TokenError = TokenError_NoFunds | TokenError_WouldDie | TokenError_BelowMinimum | TokenError_CannotCreate | TokenError_UnknownAsset | TokenError_Frozen | TokenError_Unsupported
+export type TokenError = TokenError_FundsUnavailable | TokenError_OnlyProvider | TokenError_BelowMinimum | TokenError_CannotCreate | TokenError_UnknownAsset | TokenError_Frozen | TokenError_Unsupported | TokenError_CannotCreateHold | TokenError_NotExpendable | TokenError_Blocked
 
-export interface TokenError_NoFunds {
-    __kind: 'NoFunds'
+export interface TokenError_FundsUnavailable {
+    __kind: 'FundsUnavailable'
 }
 
-export interface TokenError_WouldDie {
-    __kind: 'WouldDie'
+export interface TokenError_OnlyProvider {
+    __kind: 'OnlyProvider'
 }
 
 export interface TokenError_BelowMinimum {
@@ -462,6 +585,18 @@ export interface TokenError_Frozen {
 
 export interface TokenError_Unsupported {
     __kind: 'Unsupported'
+}
+
+export interface TokenError_CannotCreateHold {
+    __kind: 'CannotCreateHold'
+}
+
+export interface TokenError_NotExpendable {
+    __kind: 'NotExpendable'
+}
+
+export interface TokenError_Blocked {
+    __kind: 'Blocked'
 }
 
 export type ArithmeticError = ArithmeticError_Underflow | ArithmeticError_Overflow | ArithmeticError_DivisionByZero
@@ -512,45 +647,36 @@ export interface Pays_No {
     __kind: 'No'
 }
 
-export interface Bundle {
+export interface SealedBundleHeader {
     header: BundleHeader
-    receipts: ExecutionReceipt[]
-    extrinsics: Uint8Array[]
-}
-
-export type BundleSolution = BundleSolution_System | BundleSolution_Core
-
-export interface BundleSolution_System {
-    __kind: 'System'
-    authorityStakeWeight: bigint
-    authorityWitness: Type_153
-    proofOfElection: ProofOfElection
-}
-
-export interface BundleSolution_Core {
-    __kind: 'Core'
-    proofOfElection: ProofOfElection
-    coreBlockNumber: number
-    coreBlockHash: Uint8Array
-    coreStateRoot: Uint8Array
-}
-
-export interface BundleHeader {
-    primaryNumber: number
-    primaryHash: Uint8Array
-    slotNumber: bigint
-    extrinsicsRoot: Uint8Array
+    signature: Uint8Array
 }
 
 export interface InvalidStateTransitionProof {
     domainId: number
     badReceiptHash: Uint8Array
     parentNumber: number
-    primaryParentHash: Uint8Array
+    consensusParentHash: Uint8Array
     preStateRoot: Uint8Array
     postStateRoot: Uint8Array
     proof: StorageProof
     executionPhase: ExecutionPhase
+}
+
+export interface InvalidTransactionProof {
+    domainId: number
+    blockNumber: number
+    domainBlockHash: Uint8Array
+    invalidExtrinsic: Uint8Array
+    storageProof: StorageProof
+}
+
+export interface BundleEquivocationProof {
+    domainId: number
+    offender: Uint8Array
+    slot: bigint
+    firstHeader: SealedBundleHeader
+    secondHeader: SealedBundleHeader
 }
 
 export interface ImproperTransactionSortitionProof {
@@ -576,15 +702,12 @@ export interface Vote_V0 {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type SystemCall = SystemCall_remark | SystemCall_set_heap_pages | SystemCall_set_code | SystemCall_set_code_without_checks | SystemCall_set_storage | SystemCall_kill_storage | SystemCall_kill_prefix | SystemCall_remark_with_event
 
 /**
- * Make some on-chain remark.
- * 
- * ## Complexity
- * - `O(1)`
+ * See [`Pallet::remark`].
  */
 export interface SystemCall_remark {
     __kind: 'remark'
@@ -592,7 +715,7 @@ export interface SystemCall_remark {
 }
 
 /**
- * Set the number of pages in the WebAssembly environment's heap.
+ * See [`Pallet::set_heap_pages`].
  */
 export interface SystemCall_set_heap_pages {
     __kind: 'set_heap_pages'
@@ -600,10 +723,7 @@ export interface SystemCall_set_heap_pages {
 }
 
 /**
- * Set the new runtime code.
- * 
- * ## Complexity
- * - `O(C + S)` where `C` length of `code` and `S` complexity of `can_set_code`
+ * See [`Pallet::set_code`].
  */
 export interface SystemCall_set_code {
     __kind: 'set_code'
@@ -611,10 +731,7 @@ export interface SystemCall_set_code {
 }
 
 /**
- * Set the new runtime code without doing any checks of the given `code`.
- * 
- * ## Complexity
- * - `O(C)` where `C` length of `code`
+ * See [`Pallet::set_code_without_checks`].
  */
 export interface SystemCall_set_code_without_checks {
     __kind: 'set_code_without_checks'
@@ -622,7 +739,7 @@ export interface SystemCall_set_code_without_checks {
 }
 
 /**
- * Set some items of storage.
+ * See [`Pallet::set_storage`].
  */
 export interface SystemCall_set_storage {
     __kind: 'set_storage'
@@ -630,7 +747,7 @@ export interface SystemCall_set_storage {
 }
 
 /**
- * Kill some items from storage.
+ * See [`Pallet::kill_storage`].
  */
 export interface SystemCall_kill_storage {
     __kind: 'kill_storage'
@@ -638,10 +755,7 @@ export interface SystemCall_kill_storage {
 }
 
 /**
- * Kill all storage items with a key that starts with the given prefix.
- * 
- * **NOTE:** We rely on the Root origin to provide us the number of subkeys under
- * the prefix we are removing to accurately calculate the weight of this function.
+ * See [`Pallet::kill_prefix`].
  */
 export interface SystemCall_kill_prefix {
     __kind: 'kill_prefix'
@@ -650,7 +764,7 @@ export interface SystemCall_kill_prefix {
 }
 
 /**
- * Make some on-chain remark and emit event.
+ * See [`Pallet::remark_with_event`].
  */
 export interface SystemCall_remark_with_event {
     __kind: 'remark_with_event'
@@ -658,26 +772,12 @@ export interface SystemCall_remark_with_event {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type TimestampCall = TimestampCall_set
 
 /**
- * Set the current time.
- * 
- * This call should be invoked exactly once per block. It will panic at the finalization
- * phase, if this call hasn't been invoked by that time.
- * 
- * The timestamp should be greater than the previous one by the amount specified by
- * `MinimumPeriod`.
- * 
- * The dispatch origin for this call must be `Inherent`.
- * 
- * ## Complexity
- * - `O(1)` (Note that implementations of `OnTimestampSet` must also be `O(1)`)
- * - 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in
- *   `on_finalize`)
- * - 1 event handler `on_timestamp_set`. Must be `O(1)`.
+ * See [`Pallet::set`].
  */
 export interface TimestampCall_set {
     __kind: 'set'
@@ -685,17 +785,12 @@ export interface TimestampCall_set {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type SubspaceCall = SubspaceCall_report_equivocation | SubspaceCall_store_segment_headers | SubspaceCall_enable_solution_range_adjustment | SubspaceCall_vote | SubspaceCall_enable_rewards | SubspaceCall_enable_storage_access | SubspaceCall_enable_authoring_by_anyone
 
 /**
- * Report farmer equivocation/misbehavior. This method will verify the equivocation proof.
- * If valid, the offence will be reported.
- * 
- * This extrinsic must be called unsigned and it is expected that only block authors will
- * call it (validated in `ValidateUnsigned`), as such if the block author is defined it
- * will be defined as the equivocation reporter.
+ * See [`Pallet::report_equivocation`].
  */
 export interface SubspaceCall_report_equivocation {
     __kind: 'report_equivocation'
@@ -703,8 +798,7 @@ export interface SubspaceCall_report_equivocation {
 }
 
 /**
- * Submit new segment header to the blockchain. This is an inherent extrinsic and part of
- * the Subspace consensus logic.
+ * See [`Pallet::store_segment_headers`].
  */
 export interface SubspaceCall_store_segment_headers {
     __kind: 'store_segment_headers'
@@ -712,8 +806,7 @@ export interface SubspaceCall_store_segment_headers {
 }
 
 /**
- * Enable solution range adjustment after every era.
- * Note: No effect on the solution range for the current era
+ * See [`Pallet::enable_solution_range_adjustment`].
  */
 export interface SubspaceCall_enable_solution_range_adjustment {
     __kind: 'enable_solution_range_adjustment'
@@ -722,7 +815,7 @@ export interface SubspaceCall_enable_solution_range_adjustment {
 }
 
 /**
- * Farmer vote, currently only used for extra rewards to farmers.
+ * See [`Pallet::vote`].
  */
 export interface SubspaceCall_vote {
     __kind: 'vote'
@@ -730,7 +823,7 @@ export interface SubspaceCall_vote {
 }
 
 /**
- * Enable rewards for blocks and votes at specified block height.
+ * See [`Pallet::enable_rewards`].
  */
 export interface SubspaceCall_enable_rewards {
     __kind: 'enable_rewards'
@@ -738,77 +831,45 @@ export interface SubspaceCall_enable_rewards {
 }
 
 /**
- * Enable storage access for all users.
+ * See [`Pallet::enable_storage_access`].
  */
 export interface SubspaceCall_enable_storage_access {
     __kind: 'enable_storage_access'
 }
 
 /**
- * Enable storage access for all users.
+ * See [`Pallet::enable_authoring_by_anyone`].
  */
 export interface SubspaceCall_enable_authoring_by_anyone {
     __kind: 'enable_authoring_by_anyone'
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
-export type BalancesCall = BalancesCall_transfer | BalancesCall_set_balance | BalancesCall_force_transfer | BalancesCall_transfer_keep_alive | BalancesCall_transfer_all | BalancesCall_force_unreserve
+export type BalancesCall = BalancesCall_transfer_allow_death | BalancesCall_set_balance_deprecated | BalancesCall_force_transfer | BalancesCall_transfer_keep_alive | BalancesCall_transfer_all | BalancesCall_force_unreserve | BalancesCall_upgrade_accounts | BalancesCall_transfer | BalancesCall_force_set_balance
 
 /**
- * Transfer some liquid free balance to another account.
- * 
- * `transfer` will set the `FreeBalance` of the sender and receiver.
- * If the sender's account is below the existential deposit as a result
- * of the transfer, the account will be reaped.
- * 
- * The dispatch origin for this call must be `Signed` by the transactor.
- * 
- * ## Complexity
- * - Dependent on arguments but not critical, given proper implementations for input config
- *   types. See related functions below.
- * - It contains a limited number of reads and writes internally and no complex
- *   computation.
- * 
- * Related functions:
- * 
- *   - `ensure_can_withdraw` is always called internally but has a bounded complexity.
- *   - Transferring balances to accounts that did not exist before will cause
- *     `T::OnNewAccount::on_new_account` to be called.
- *   - Removing enough funds from an account will trigger `T::DustRemoval::on_unbalanced`.
- *   - `transfer_keep_alive` works the same way as `transfer`, but has an additional check
- *     that the transfer will not kill the origin account.
+ * See [`Pallet::transfer_allow_death`].
  */
-export interface BalancesCall_transfer {
-    __kind: 'transfer'
+export interface BalancesCall_transfer_allow_death {
+    __kind: 'transfer_allow_death'
     dest: MultiAddress
     value: bigint
 }
 
 /**
- * Set the balances of a given account.
- * 
- * This will alter `FreeBalance` and `ReservedBalance` in storage. it will
- * also alter the total issuance of the system (`TotalIssuance`) appropriately.
- * If the new free or reserved balance is below the existential deposit,
- * it will reset the account nonce (`frame_system::AccountNonce`).
- * 
- * The dispatch origin for this call is `root`.
+ * See [`Pallet::set_balance_deprecated`].
  */
-export interface BalancesCall_set_balance {
-    __kind: 'set_balance'
+export interface BalancesCall_set_balance_deprecated {
+    __kind: 'set_balance_deprecated'
     who: MultiAddress
     newFree: bigint
-    newReserved: bigint
+    oldReserved: bigint
 }
 
 /**
- * Exactly as `transfer`, except the origin must be root and the source account may be
- * specified.
- * ## Complexity
- * - Same as transfer, but additional read and write because the source account is not
- *   assumed to be in the overlay.
+ * See [`Pallet::force_transfer`].
  */
 export interface BalancesCall_force_transfer {
     __kind: 'force_transfer'
@@ -818,12 +879,7 @@ export interface BalancesCall_force_transfer {
 }
 
 /**
- * Same as the [`transfer`] call, but with a check that the transfer will not kill the
- * origin account.
- * 
- * 99% of the time you want [`transfer`] instead.
- * 
- * [`transfer`]: struct.Pallet.html#method.transfer
+ * See [`Pallet::transfer_keep_alive`].
  */
 export interface BalancesCall_transfer_keep_alive {
     __kind: 'transfer_keep_alive'
@@ -832,22 +888,7 @@ export interface BalancesCall_transfer_keep_alive {
 }
 
 /**
- * Transfer the entire transferable balance from the caller account.
- * 
- * NOTE: This function only attempts to transfer _transferable_ balances. This means that
- * any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be
- * transferred by this function. To ensure that this function results in a killed account,
- * you might need to prepare the account by removing any reference counters, storage
- * deposits, etc...
- * 
- * The dispatch origin of this call must be Signed.
- * 
- * - `dest`: The recipient of the transfer.
- * - `keep_alive`: A boolean to determine if the `transfer_all` operation should send all
- *   of the funds the account has, causing the sender account to be killed (false), or
- *   transfer everything except at least the existential deposit, which will guarantee to
- *   keep the sender account alive (true). ## Complexity
- * - O(1). Just like transfer, but reading the user's transferable balance first.
+ * See [`Pallet::transfer_all`].
  */
 export interface BalancesCall_transfer_all {
     __kind: 'transfer_all'
@@ -856,9 +897,7 @@ export interface BalancesCall_transfer_all {
 }
 
 /**
- * Unreserve some balance from a user by force.
- * 
- * Can only be called by ROOT.
+ * See [`Pallet::force_unreserve`].
  */
 export interface BalancesCall_force_unreserve {
     __kind: 'force_unreserve'
@@ -867,29 +906,38 @@ export interface BalancesCall_force_unreserve {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * See [`Pallet::upgrade_accounts`].
+ */
+export interface BalancesCall_upgrade_accounts {
+    __kind: 'upgrade_accounts'
+    who: Uint8Array[]
+}
+
+/**
+ * See [`Pallet::transfer`].
+ */
+export interface BalancesCall_transfer {
+    __kind: 'transfer'
+    dest: MultiAddress
+    value: bigint
+}
+
+/**
+ * See [`Pallet::force_set_balance`].
+ */
+export interface BalancesCall_force_set_balance {
+    __kind: 'force_set_balance'
+    who: MultiAddress
+    newFree: bigint
+}
+
+/**
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type UtilityCall = UtilityCall_batch | UtilityCall_as_derivative | UtilityCall_batch_all | UtilityCall_dispatch_as | UtilityCall_force_batch | UtilityCall_with_weight
 
 /**
- * Send a batch of dispatch calls.
- * 
- * May be called from any origin except `None`.
- * 
- * - `calls`: The calls to be dispatched from the same origin. The number of call must not
- *   exceed the constant: `batched_calls_limit` (available in constant metadata).
- * 
- * If origin is root then the calls are dispatched without checking origin filter. (This
- * includes bypassing `frame_system::Config::BaseCallFilter`).
- * 
- * ## Complexity
- * - O(C) where C is the number of calls to be batched.
- * 
- * This will return `Ok` in all circumstances. To determine the success of the batch, an
- * event is deposited. If a call failed and the batch was interrupted, then the
- * `BatchInterrupted` event is deposited, along with the number of successful calls made
- * and the error of the failed call. If all were successful, then the `BatchCompleted`
- * event is deposited.
+ * See [`Pallet::batch`].
  */
 export interface UtilityCall_batch {
     __kind: 'batch'
@@ -897,19 +945,7 @@ export interface UtilityCall_batch {
 }
 
 /**
- * Send a call through an indexed pseudonym of the sender.
- * 
- * Filter from origin are passed along. The call will be dispatched with an origin which
- * use the same filter as the origin of this call.
- * 
- * NOTE: If you need to ensure that any account-based filtering is not honored (i.e.
- * because you expect `proxy` to have been used prior in the call stack and you do not want
- * the call restrictions to apply to any sub-accounts), then use `as_multi_threshold_1`
- * in the Multisig pallet instead.
- * 
- * NOTE: Prior to version *12, this was called `as_limited_sub`.
- * 
- * The dispatch origin for this call must be _Signed_.
+ * See [`Pallet::as_derivative`].
  */
 export interface UtilityCall_as_derivative {
     __kind: 'as_derivative'
@@ -918,19 +954,7 @@ export interface UtilityCall_as_derivative {
 }
 
 /**
- * Send a batch of dispatch calls and atomically execute them.
- * The whole transaction will rollback and fail if any of the calls failed.
- * 
- * May be called from any origin except `None`.
- * 
- * - `calls`: The calls to be dispatched from the same origin. The number of call must not
- *   exceed the constant: `batched_calls_limit` (available in constant metadata).
- * 
- * If origin is root then the calls are dispatched without checking origin filter. (This
- * includes bypassing `frame_system::Config::BaseCallFilter`).
- * 
- * ## Complexity
- * - O(C) where C is the number of calls to be batched.
+ * See [`Pallet::batch_all`].
  */
 export interface UtilityCall_batch_all {
     __kind: 'batch_all'
@@ -938,12 +962,7 @@ export interface UtilityCall_batch_all {
 }
 
 /**
- * Dispatches a function call with a provided origin.
- * 
- * The dispatch origin for this call must be _Root_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::dispatch_as`].
  */
 export interface UtilityCall_dispatch_as {
     __kind: 'dispatch_as'
@@ -952,19 +971,7 @@ export interface UtilityCall_dispatch_as {
 }
 
 /**
- * Send a batch of dispatch calls.
- * Unlike `batch`, it allows errors and won't interrupt.
- * 
- * May be called from any origin except `None`.
- * 
- * - `calls`: The calls to be dispatched from the same origin. The number of call must not
- *   exceed the constant: `batched_calls_limit` (available in constant metadata).
- * 
- * If origin is root then the calls are dispatch without checking origin filter. (This
- * includes bypassing `frame_system::Config::BaseCallFilter`).
- * 
- * ## Complexity
- * - O(C) where C is the number of calls to be batched.
+ * See [`Pallet::force_batch`].
  */
 export interface UtilityCall_force_batch {
     __kind: 'force_batch'
@@ -972,12 +979,7 @@ export interface UtilityCall_force_batch {
 }
 
 /**
- * Dispatch a function call with a specified weight.
- * 
- * This function does not check the weight of the call, and instead allows the
- * Root origin to specify the weight of the call.
- * 
- * The dispatch origin for this call must be _Root_.
+ * See [`Pallet::with_weight`].
  */
 export interface UtilityCall_with_weight {
     __kind: 'with_weight'
@@ -986,12 +988,12 @@ export interface UtilityCall_with_weight {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type FeedsCall = FeedsCall_create | FeedsCall_update | FeedsCall_put | FeedsCall_close | FeedsCall_transfer
 
 /**
- * Create a new feed
+ * See [`Pallet::create`].
  */
 export interface FeedsCall_create {
     __kind: 'create'
@@ -1000,7 +1002,7 @@ export interface FeedsCall_create {
 }
 
 /**
- * Updates the feed with init data provided.
+ * See [`Pallet::update`].
  */
 export interface FeedsCall_update {
     __kind: 'update'
@@ -1010,7 +1012,7 @@ export interface FeedsCall_update {
 }
 
 /**
- * Put a new object into a feed
+ * See [`Pallet::put`].
  */
 export interface FeedsCall_put {
     __kind: 'put'
@@ -1019,7 +1021,7 @@ export interface FeedsCall_put {
 }
 
 /**
- * Closes the feed and stops accepting new feed.
+ * See [`Pallet::close`].
  */
 export interface FeedsCall_close {
     __kind: 'close'
@@ -1027,7 +1029,7 @@ export interface FeedsCall_close {
 }
 
 /**
- * Transfers feed from current owner to new owner
+ * See [`Pallet::transfer`].
  */
 export interface FeedsCall_transfer {
     __kind: 'transfer'
@@ -1036,12 +1038,12 @@ export interface FeedsCall_transfer {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type ObjectStoreCall = ObjectStoreCall_put
 
 /**
- * Put a new object into a feed
+ * See [`Pallet::put`].
  */
 export interface ObjectStoreCall_put {
     __kind: 'put'
@@ -1049,68 +1051,151 @@ export interface ObjectStoreCall_put {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
-export type DomainsCall = DomainsCall_submit_bundle | DomainsCall_submit_fraud_proof | DomainsCall_submit_bundle_equivocation_proof | DomainsCall_submit_invalid_transaction_proof
+export type DomainsCall = DomainsCall_submit_bundle | DomainsCall_submit_fraud_proof | DomainsCall_register_domain_runtime | DomainsCall_upgrade_domain_runtime | DomainsCall_register_operator | DomainsCall_nominate_operator | DomainsCall_instantiate_domain | DomainsCall_switch_domain | DomainsCall_deregister_operator | DomainsCall_withdraw_stake | DomainsCall_auto_stake_block_rewards
 
+/**
+ * See [`Pallet::submit_bundle`].
+ */
 export interface DomainsCall_submit_bundle {
     __kind: 'submit_bundle'
-    signedOpaqueBundle: SignedBundle
+    opaqueBundle: Bundle
 }
 
+/**
+ * See [`Pallet::submit_fraud_proof`].
+ */
 export interface DomainsCall_submit_fraud_proof {
     __kind: 'submit_fraud_proof'
     fraudProof: FraudProof
 }
 
-export interface DomainsCall_submit_bundle_equivocation_proof {
-    __kind: 'submit_bundle_equivocation_proof'
-    bundleEquivocationProof: BundleEquivocationProof
-}
-
-export interface DomainsCall_submit_invalid_transaction_proof {
-    __kind: 'submit_invalid_transaction_proof'
-    invalidTransactionProof: InvalidTransactionProof
+/**
+ * See [`Pallet::register_domain_runtime`].
+ */
+export interface DomainsCall_register_domain_runtime {
+    __kind: 'register_domain_runtime'
+    runtimeName: Uint8Array
+    runtimeType: RuntimeType
+    code: Uint8Array
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * See [`Pallet::upgrade_domain_runtime`].
+ */
+export interface DomainsCall_upgrade_domain_runtime {
+    __kind: 'upgrade_domain_runtime'
+    runtimeId: number
+    code: Uint8Array
+}
+
+/**
+ * See [`Pallet::register_operator`].
+ */
+export interface DomainsCall_register_operator {
+    __kind: 'register_operator'
+    domainId: number
+    amount: bigint
+    config: OperatorConfig
+}
+
+/**
+ * See [`Pallet::nominate_operator`].
+ */
+export interface DomainsCall_nominate_operator {
+    __kind: 'nominate_operator'
+    operatorId: bigint
+    amount: bigint
+}
+
+/**
+ * See [`Pallet::instantiate_domain`].
+ */
+export interface DomainsCall_instantiate_domain {
+    __kind: 'instantiate_domain'
+    domainConfig: DomainConfig
+}
+
+/**
+ * See [`Pallet::switch_domain`].
+ */
+export interface DomainsCall_switch_domain {
+    __kind: 'switch_domain'
+    operatorId: bigint
+    newDomainId: number
+}
+
+/**
+ * See [`Pallet::deregister_operator`].
+ */
+export interface DomainsCall_deregister_operator {
+    __kind: 'deregister_operator'
+    operatorId: bigint
+}
+
+/**
+ * See [`Pallet::withdraw_stake`].
+ */
+export interface DomainsCall_withdraw_stake {
+    __kind: 'withdraw_stake'
+    operatorId: bigint
+    withdraw: Withdraw
+}
+
+/**
+ * See [`Pallet::auto_stake_block_rewards`].
+ */
+export interface DomainsCall_auto_stake_block_rewards {
+    __kind: 'auto_stake_block_rewards'
+    operatorId: bigint
+}
+
+/**
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type VestingCall = VestingCall_claim | VestingCall_vested_transfer | VestingCall_update_vesting_schedules | VestingCall_claim_for
 
+/**
+ * See [`Pallet::claim`].
+ */
 export interface VestingCall_claim {
     __kind: 'claim'
 }
 
+/**
+ * See [`Pallet::vested_transfer`].
+ */
 export interface VestingCall_vested_transfer {
     __kind: 'vested_transfer'
     dest: MultiAddress
     schedule: VestingSchedule
 }
 
+/**
+ * See [`Pallet::update_vesting_schedules`].
+ */
 export interface VestingCall_update_vesting_schedules {
     __kind: 'update_vesting_schedules'
     who: MultiAddress
     vestingSchedules: VestingSchedule[]
 }
 
+/**
+ * See [`Pallet::claim_for`].
+ */
 export interface VestingCall_claim_for {
     __kind: 'claim_for'
     dest: MultiAddress
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type SudoCall = SudoCall_sudo | SudoCall_sudo_unchecked_weight | SudoCall_set_key | SudoCall_sudo_as
 
 /**
- * Authenticates the sudo key and dispatches a function call with `Root` origin.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::sudo`].
  */
 export interface SudoCall_sudo {
     __kind: 'sudo'
@@ -1118,14 +1203,7 @@ export interface SudoCall_sudo {
 }
 
 /**
- * Authenticates the sudo key and dispatches a function call with `Root` origin.
- * This function does not check the weight of the call, and instead allows the
- * Sudo user to specify the weight of the call.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::sudo_unchecked_weight`].
  */
 export interface SudoCall_sudo_unchecked_weight {
     __kind: 'sudo_unchecked_weight'
@@ -1134,13 +1212,7 @@ export interface SudoCall_sudo_unchecked_weight {
 }
 
 /**
- * Authenticates the current sudo key and sets the given AccountId (`new`) as the new sudo
- * key.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::set_key`].
  */
 export interface SudoCall_set_key {
     __kind: 'set_key'
@@ -1148,13 +1220,7 @@ export interface SudoCall_set_key {
 }
 
 /**
- * Authenticates the sudo key and dispatches a function call with `Signed` origin from
- * a given account.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::sudo_as`].
  */
 export interface SudoCall_sudo_as {
     __kind: 'sudo_as'
@@ -1179,6 +1245,13 @@ export interface RawOrigin_None {
 
 export type Void = never
 
+export type HoldIdentifier = HoldIdentifier_Domains
+
+export interface HoldIdentifier_Domains {
+    __kind: 'Domains'
+    value: DomainsHoldIdentifier
+}
+
 export type Reasons = Reasons_Fee | Reasons_Misc | Reasons_All
 
 export interface Reasons_Fee {
@@ -1191,6 +1264,34 @@ export interface Reasons_Misc {
 
 export interface Reasons_All {
     __kind: 'All'
+}
+
+export interface ExecutionReceipt {
+    domainBlockNumber: number
+    domainBlockHash: Uint8Array
+    parentDomainBlockReceiptHash: Uint8Array
+    consensusBlockNumber: number
+    consensusBlockHash: Uint8Array
+    invalidBundles: InvalidBundle[]
+    blockExtrinsicsRoots: Uint8Array[]
+    finalStateRoot: Uint8Array
+    executionTrace: Uint8Array[]
+    executionTraceRoot: Uint8Array
+    totalRewards: bigint
+}
+
+export type OperatorStatus = OperatorStatus_Registered | OperatorStatus_Deregistered | OperatorStatus_Slashed
+
+export interface OperatorStatus_Registered {
+    __kind: 'Registered'
+}
+
+export interface OperatorStatus_Deregistered {
+    __kind: 'Deregistered'
+}
+
+export interface OperatorStatus_Slashed {
+    __kind: 'Slashed'
 }
 
 export type DigestItem = DigestItem_PreRuntime | DigestItem_Consensus | DigestItem_Seal | DigestItem_Other | DigestItem_RuntimeEnvironmentUpdated
@@ -1219,7 +1320,7 @@ export interface DigestItem_RuntimeEnvironmentUpdated {
     __kind: 'RuntimeEnvironmentUpdated'
 }
 
-export type Event = Event_System | Event_Subspace | Event_OffencesSubspace | Event_Rewards | Event_Balances | Event_TransactionFees | Event_TransactionPayment | Event_Utility | Event_Feeds | Event_ObjectStore | Event_Receipts | Event_Domains | Event_Vesting | Event_Sudo
+export type Event = Event_System | Event_Subspace | Event_OffencesSubspace | Event_Rewards | Event_Balances | Event_TransactionFees | Event_TransactionPayment | Event_Utility | Event_Feeds | Event_ObjectStore | Event_Domains | Event_Vesting | Event_Sudo
 
 export interface Event_System {
     __kind: 'System'
@@ -1271,11 +1372,6 @@ export interface Event_ObjectStore {
     value: ObjectStoreEvent
 }
 
-export interface Event_Receipts {
-    __kind: 'Receipts'
-    value: ReceiptsEvent
-}
-
 export interface Event_Domains {
     __kind: 'Domains'
     value: DomainsEvent
@@ -1314,22 +1410,12 @@ export interface ArchivedBlockProgress_Partial {
     value: number
 }
 
-export interface Type_153 {
-    leafIndex: number
-    proof: Uint8Array
-    numberOfLeaves: number
-}
-
-export interface ProofOfElection {
-    domainId: number
-    vrfOutput: Uint8Array
-    vrfProof: Uint8Array
-    executorPublicKey: Uint8Array
-    globalChallenge: Uint8Array
-    stateRoot: Uint8Array
-    storageProof: StorageProof
-    blockNumber: number
-    blockHash: Uint8Array
+export interface BundleHeader {
+    proofOfElection: ProofOfElection
+    receipt: ExecutionReceipt
+    bundleSize: number
+    estimatedBundleWeight: Weight
+    bundleExtrinsicsRoot: Uint8Array
 }
 
 export interface StorageProof {
@@ -1356,14 +1442,32 @@ export interface ExecutionPhase_FinalizeBlock {
 export interface Solution {
     publicKey: Uint8Array
     rewardAddress: Uint8Array
-    sectorIndex: bigint
-    totalPieces: bigint
-    pieceOffset: bigint
-    recordCommitmentHash: Scalar
-    pieceWitness: Witness
-    chunkOffset: number
+    sectorIndex: number
+    historySize: bigint
+    pieceOffset: number
+    recordCommitment: Commitment
+    recordWitness: Witness
     chunk: Scalar
-    chunkSignature: ChunkSignature
+    chunkWitness: Witness
+    auditChunkOffset: number
+    proofOfSpace: Uint8Array
+}
+
+export type DomainsHoldIdentifier = DomainsHoldIdentifier_Staking | DomainsHoldIdentifier_DomainInstantiation
+
+export interface DomainsHoldIdentifier_Staking {
+    __kind: 'Staking'
+    value: StakingHoldIdentifier
+}
+
+export interface DomainsHoldIdentifier_DomainInstantiation {
+    __kind: 'DomainInstantiation'
+    value: number
+}
+
+export interface InvalidBundle {
+    bundleIndex: number
+    invalidBundleType: InvalidBundleType
 }
 
 /**
@@ -1484,12 +1588,9 @@ export interface RewardsEvent_VoteReward {
 }
 
 /**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
+ * The `Event` enum of this pallet
  */
-export type BalancesEvent = BalancesEvent_Endowed | BalancesEvent_DustLost | BalancesEvent_Transfer | BalancesEvent_BalanceSet | BalancesEvent_Reserved | BalancesEvent_Unreserved | BalancesEvent_ReserveRepatriated | BalancesEvent_Deposit | BalancesEvent_Withdraw | BalancesEvent_Slashed
+export type BalancesEvent = BalancesEvent_Endowed | BalancesEvent_DustLost | BalancesEvent_Transfer | BalancesEvent_BalanceSet | BalancesEvent_Reserved | BalancesEvent_Unreserved | BalancesEvent_ReserveRepatriated | BalancesEvent_Deposit | BalancesEvent_Withdraw | BalancesEvent_Slashed | BalancesEvent_Minted | BalancesEvent_Burned | BalancesEvent_Suspended | BalancesEvent_Restored | BalancesEvent_Upgraded | BalancesEvent_Issued | BalancesEvent_Rescinded | BalancesEvent_Locked | BalancesEvent_Unlocked | BalancesEvent_Frozen | BalancesEvent_Thawed
 
 /**
  * An account was created with some free balance.
@@ -1527,7 +1628,6 @@ export interface BalancesEvent_BalanceSet {
     __kind: 'BalanceSet'
     who: Uint8Array
     free: bigint
-    reserved: bigint
 }
 
 /**
@@ -1583,6 +1683,102 @@ export interface BalancesEvent_Withdraw {
  */
 export interface BalancesEvent_Slashed {
     __kind: 'Slashed'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * Some amount was minted into an account.
+ */
+export interface BalancesEvent_Minted {
+    __kind: 'Minted'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * Some amount was burned from an account.
+ */
+export interface BalancesEvent_Burned {
+    __kind: 'Burned'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * Some amount was suspended from an account (it can be restored later).
+ */
+export interface BalancesEvent_Suspended {
+    __kind: 'Suspended'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * Some amount was restored into an account.
+ */
+export interface BalancesEvent_Restored {
+    __kind: 'Restored'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * An account was upgraded.
+ */
+export interface BalancesEvent_Upgraded {
+    __kind: 'Upgraded'
+    who: Uint8Array
+}
+
+/**
+ * Total issuance was increased by `amount`, creating a credit to be balanced.
+ */
+export interface BalancesEvent_Issued {
+    __kind: 'Issued'
+    amount: bigint
+}
+
+/**
+ * Total issuance was decreased by `amount`, creating a debt to be balanced.
+ */
+export interface BalancesEvent_Rescinded {
+    __kind: 'Rescinded'
+    amount: bigint
+}
+
+/**
+ * Some balance was locked.
+ */
+export interface BalancesEvent_Locked {
+    __kind: 'Locked'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * Some balance was unlocked.
+ */
+export interface BalancesEvent_Unlocked {
+    __kind: 'Unlocked'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * Some balance was frozen.
+ */
+export interface BalancesEvent_Frozen {
+    __kind: 'Frozen'
+    who: Uint8Array
+    amount: bigint
+}
+
+/**
+ * Some balance was thawed.
+ */
+export interface BalancesEvent_Thawed {
+    __kind: 'Thawed'
     who: Uint8Array
     amount: bigint
 }
@@ -1653,10 +1849,7 @@ export interface TransactionFeesEvent_TipsReward {
 }
 
 /**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
+ * The `Event` enum of this pallet
  */
 export type TransactionPaymentEvent = TransactionPaymentEvent_TransactionFeePaid
 
@@ -1672,10 +1865,7 @@ export interface TransactionPaymentEvent_TransactionFeePaid {
 }
 
 /**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
+ * The `Event` enum of this pallet
  */
 export type UtilityEvent = UtilityEvent_BatchInterrupted | UtilityEvent_BatchCompleted | UtilityEvent_BatchCompletedWithErrors | UtilityEvent_ItemCompleted | UtilityEvent_ItemFailed | UtilityEvent_DispatchedAs
 
@@ -1723,7 +1913,7 @@ export interface UtilityEvent_ItemFailed {
  */
 export interface UtilityEvent_DispatchedAs {
     __kind: 'DispatchedAs'
-    result: Type_46
+    result: Type_47
 }
 
 /**
@@ -1804,40 +1994,9 @@ export interface ObjectStoreEvent_ObjectSubmitted {
 }
 
 /**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
+ * The `Event` enum of this pallet
  */
-export type ReceiptsEvent = ReceiptsEvent_NewDomainReceipt | ReceiptsEvent_FraudProofProcessed
-
-/**
- * A new domain receipt.
- */
-export interface ReceiptsEvent_NewDomainReceipt {
-    __kind: 'NewDomainReceipt'
-    domainId: number
-    primaryNumber: number
-    primaryHash: Uint8Array
-}
-
-/**
- * A fraud proof was processed.
- */
-export interface ReceiptsEvent_FraudProofProcessed {
-    __kind: 'FraudProofProcessed'
-    domainId: number
-    newBestNumber: number
-    newBestHash: Uint8Array
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type DomainsEvent = DomainsEvent_BundleStored | DomainsEvent_BundleEquivocationProofProcessed | DomainsEvent_InvalidTransactionProofProcessed
+export type DomainsEvent = DomainsEvent_BundleStored | DomainsEvent_DomainRuntimeCreated | DomainsEvent_DomainRuntimeUpgradeScheduled | DomainsEvent_DomainRuntimeUpgraded | DomainsEvent_OperatorRegistered | DomainsEvent_OperatorNominated | DomainsEvent_DomainInstantiated | DomainsEvent_OperatorSwitchedDomain | DomainsEvent_OperatorDeregistered | DomainsEvent_WithdrewStake | DomainsEvent_PreferredOperator | DomainsEvent_OperatorRewarded | DomainsEvent_DomainEpochCompleted
 
 /**
  * A domain bundle was included.
@@ -1846,28 +2005,80 @@ export interface DomainsEvent_BundleStored {
     __kind: 'BundleStored'
     domainId: number
     bundleHash: Uint8Array
-    bundleAuthor: Uint8Array
+    bundleAuthor: bigint
+}
+
+export interface DomainsEvent_DomainRuntimeCreated {
+    __kind: 'DomainRuntimeCreated'
+    runtimeId: number
+    runtimeType: RuntimeType
+}
+
+export interface DomainsEvent_DomainRuntimeUpgradeScheduled {
+    __kind: 'DomainRuntimeUpgradeScheduled'
+    runtimeId: number
+    scheduledAt: number
+}
+
+export interface DomainsEvent_DomainRuntimeUpgraded {
+    __kind: 'DomainRuntimeUpgraded'
+    runtimeId: number
+}
+
+export interface DomainsEvent_OperatorRegistered {
+    __kind: 'OperatorRegistered'
+    operatorId: bigint
+    domainId: number
+}
+
+export interface DomainsEvent_OperatorNominated {
+    __kind: 'OperatorNominated'
+    operatorId: bigint
+    nominatorId: Uint8Array
+}
+
+export interface DomainsEvent_DomainInstantiated {
+    __kind: 'DomainInstantiated'
+    domainId: number
+}
+
+export interface DomainsEvent_OperatorSwitchedDomain {
+    __kind: 'OperatorSwitchedDomain'
+    oldDomainId: number
+    newDomainId: number
+}
+
+export interface DomainsEvent_OperatorDeregistered {
+    __kind: 'OperatorDeregistered'
+    operatorId: bigint
+}
+
+export interface DomainsEvent_WithdrewStake {
+    __kind: 'WithdrewStake'
+    operatorId: bigint
+    nominatorId: Uint8Array
+}
+
+export interface DomainsEvent_PreferredOperator {
+    __kind: 'PreferredOperator'
+    operatorId: bigint
+    nominatorId: Uint8Array
+}
+
+export interface DomainsEvent_OperatorRewarded {
+    __kind: 'OperatorRewarded'
+    operatorId: bigint
+    reward: bigint
+}
+
+export interface DomainsEvent_DomainEpochCompleted {
+    __kind: 'DomainEpochCompleted'
+    domainId: number
+    completedEpochIndex: number
 }
 
 /**
- * A bundle equivocation proof was processed.
- */
-export interface DomainsEvent_BundleEquivocationProofProcessed {
-    __kind: 'BundleEquivocationProofProcessed'
-}
-
-/**
- * An invalid transaction proof was processed.
- */
-export interface DomainsEvent_InvalidTransactionProofProcessed {
-    __kind: 'InvalidTransactionProofProcessed'
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
+ * The `Event` enum of this pallet
  */
 export type VestingEvent = VestingEvent_VestingScheduleAdded | VestingEvent_Claimed | VestingEvent_VestingSchedulesUpdated
 
@@ -1899,10 +2110,7 @@ export interface VestingEvent_VestingSchedulesUpdated {
 }
 
 /**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
+ * The `Event` enum of this pallet
  */
 export type SudoEvent = SudoEvent_Sudid | SudoEvent_KeyChanged | SudoEvent_SudoAsDone
 
@@ -1911,7 +2119,7 @@ export type SudoEvent = SudoEvent_Sudid | SudoEvent_KeyChanged | SudoEvent_SudoA
  */
 export interface SudoEvent_Sudid {
     __kind: 'Sudid'
-    sudoResult: Type_46
+    sudoResult: Type_47
 }
 
 /**
@@ -1927,7 +2135,7 @@ export interface SudoEvent_KeyChanged {
  */
 export interface SudoEvent_SudoAsDone {
     __kind: 'SudoAsDone'
-    sudoResult: Type_46
+    sudoResult: Type_47
 }
 
 export interface WeightsPerClass {
@@ -1937,15 +2145,61 @@ export interface WeightsPerClass {
     reserved: (Weight | undefined)
 }
 
-export interface Scalar {
-    inner: Uint8Array
+export interface ProofOfElection {
+    domainId: number
+    slotNumber: bigint
+    globalRandomness: Uint8Array
+    vrfSignature: VrfSignature
+    operatorId: bigint
 }
 
 export interface Witness {
     inner: Uint8Array
 }
 
-export interface ChunkSignature {
+export type StakingHoldIdentifier = StakingHoldIdentifier_PendingDeposit | StakingHoldIdentifier_Staked | StakingHoldIdentifier_PendingUnlock
+
+export interface StakingHoldIdentifier_PendingDeposit {
+    __kind: 'PendingDeposit'
+    value: bigint
+}
+
+export interface StakingHoldIdentifier_Staked {
+    __kind: 'Staked'
+    value: bigint
+}
+
+export interface StakingHoldIdentifier_PendingUnlock {
+    __kind: 'PendingUnlock'
+    value: bigint
+}
+
+export type InvalidBundleType = InvalidBundleType_UndecodableTx | InvalidBundleType_OutOfRangeTx | InvalidBundleType_IllegalTx | InvalidBundleType_InvalidReceipt
+
+export interface InvalidBundleType_UndecodableTx {
+    __kind: 'UndecodableTx'
+}
+
+export interface InvalidBundleType_OutOfRangeTx {
+    __kind: 'OutOfRangeTx'
+}
+
+export interface InvalidBundleType_IllegalTx {
+    __kind: 'IllegalTx'
+}
+
+export interface InvalidBundleType_InvalidReceipt {
+    __kind: 'InvalidReceipt'
+    value: InvalidReceipt
+}
+
+export interface VrfSignature {
     output: Uint8Array
     proof: Uint8Array
+}
+
+export type InvalidReceipt = InvalidReceipt_InvalidBundles
+
+export interface InvalidReceipt_InvalidBundles {
+    __kind: 'InvalidBundles'
 }

--- a/squid-blockexplorer/src/types/v2.ts
+++ b/squid-blockexplorer/src/types/v2.ts
@@ -1,105 +1,12 @@
 import type {Result, Option} from './support'
 
-export type Type_47 = Type_47_Ok | Type_47_Err
-
-export interface Type_47_Ok {
-    __kind: 'Ok'
-}
-
-export interface Type_47_Err {
-    __kind: 'Err'
-    value: DispatchError
-}
-
-export type DispatchError = DispatchError_Other | DispatchError_CannotLookup | DispatchError_BadOrigin | DispatchError_Module | DispatchError_ConsumerRemaining | DispatchError_NoProviders | DispatchError_TooManyConsumers | DispatchError_Token | DispatchError_Arithmetic | DispatchError_Transactional | DispatchError_Exhausted | DispatchError_Corruption | DispatchError_Unavailable
-
-export interface DispatchError_Other {
-    __kind: 'Other'
-}
-
-export interface DispatchError_CannotLookup {
-    __kind: 'CannotLookup'
-}
-
-export interface DispatchError_BadOrigin {
-    __kind: 'BadOrigin'
-}
-
-export interface DispatchError_Module {
-    __kind: 'Module'
-    value: ModuleError
-}
-
-export interface DispatchError_ConsumerRemaining {
-    __kind: 'ConsumerRemaining'
-}
-
-export interface DispatchError_NoProviders {
-    __kind: 'NoProviders'
-}
-
-export interface DispatchError_TooManyConsumers {
-    __kind: 'TooManyConsumers'
-}
-
-export interface DispatchError_Token {
-    __kind: 'Token'
-    value: TokenError
-}
-
-export interface DispatchError_Arithmetic {
-    __kind: 'Arithmetic'
-    value: ArithmeticError
-}
-
-export interface DispatchError_Transactional {
-    __kind: 'Transactional'
-    value: TransactionalError
-}
-
-export interface DispatchError_Exhausted {
-    __kind: 'Exhausted'
-}
-
-export interface DispatchError_Corruption {
-    __kind: 'Corruption'
-}
-
-export interface DispatchError_Unavailable {
-    __kind: 'Unavailable'
-}
-
-export interface DispatchInfo {
-    weight: Weight
-    class: DispatchClass
-    paysFee: Pays
-}
-
-export type MultiAddress = MultiAddress_Id | MultiAddress_Index | MultiAddress_Raw | MultiAddress_Address32 | MultiAddress_Address20
-
-export interface MultiAddress_Id {
-    __kind: 'Id'
-    value: Uint8Array
-}
-
-export interface MultiAddress_Index {
-    __kind: 'Index'
-    value: null
-}
-
-export interface MultiAddress_Raw {
-    __kind: 'Raw'
-    value: Uint8Array
-}
-
-export interface MultiAddress_Address32 {
-    __kind: 'Address32'
-    value: Uint8Array
-}
-
-export interface MultiAddress_Address20 {
-    __kind: 'Address20'
-    value: Uint8Array
+export interface DomainConfig {
+    domainName: Uint8Array
+    runtimeId: number
+    maxBlockSize: number
+    maxBlockWeight: Weight
+    bundleSlotProbability: [bigint, bigint]
+    targetBundlesPerBlock: number
 }
 
 export type Call = Call_System | Call_Timestamp | Call_Subspace | Call_Balances | Call_Utility | Call_Feeds | Call_ObjectStore | Call_Domains | Call_Vesting | Call_Sudo
@@ -154,6 +61,33 @@ export interface Call_Sudo {
     value: SudoCall
 }
 
+export type MultiAddress = MultiAddress_Id | MultiAddress_Index | MultiAddress_Raw | MultiAddress_Address32 | MultiAddress_Address20
+
+export interface MultiAddress_Id {
+    __kind: 'Id'
+    value: Uint8Array
+}
+
+export interface MultiAddress_Index {
+    __kind: 'Index'
+    value: null
+}
+
+export interface MultiAddress_Raw {
+    __kind: 'Raw'
+    value: Uint8Array
+}
+
+export interface MultiAddress_Address32 {
+    __kind: 'Address32'
+    value: Uint8Array
+}
+
+export interface MultiAddress_Address20 {
+    __kind: 'Address20'
+    value: Uint8Array
+}
+
 export interface Weight {
     refTime: bigint
     proofSize: bigint
@@ -171,132 +105,13 @@ export interface OriginCaller_Void {
     value: Void
 }
 
-export interface AccountData {
-    free: bigint
-    reserved: bigint
-    frozen: bigint
-    flags: bigint
-}
-
-export interface IdAmount {
-    amount: bigint
-}
-
-export interface AccountInfo {
-    nonce: number
-    consumers: number
-    providers: number
-    sufficients: number
-    data: AccountData
-}
-
-export interface EventRecord {
-    phase: Phase
-    event: Event
-    topics: Uint8Array[]
-}
-
-export interface ModuleError {
-    index: number
-    error: Uint8Array
-}
-
-export type TokenError = TokenError_FundsUnavailable | TokenError_OnlyProvider | TokenError_BelowMinimum | TokenError_CannotCreate | TokenError_UnknownAsset | TokenError_Frozen | TokenError_Unsupported | TokenError_CannotCreateHold | TokenError_NotExpendable
-
-export interface TokenError_FundsUnavailable {
-    __kind: 'FundsUnavailable'
-}
-
-export interface TokenError_OnlyProvider {
-    __kind: 'OnlyProvider'
-}
-
-export interface TokenError_BelowMinimum {
-    __kind: 'BelowMinimum'
-}
-
-export interface TokenError_CannotCreate {
-    __kind: 'CannotCreate'
-}
-
-export interface TokenError_UnknownAsset {
-    __kind: 'UnknownAsset'
-}
-
-export interface TokenError_Frozen {
-    __kind: 'Frozen'
-}
-
-export interface TokenError_Unsupported {
-    __kind: 'Unsupported'
-}
-
-export interface TokenError_CannotCreateHold {
-    __kind: 'CannotCreateHold'
-}
-
-export interface TokenError_NotExpendable {
-    __kind: 'NotExpendable'
-}
-
-export type ArithmeticError = ArithmeticError_Underflow | ArithmeticError_Overflow | ArithmeticError_DivisionByZero
-
-export interface ArithmeticError_Underflow {
-    __kind: 'Underflow'
-}
-
-export interface ArithmeticError_Overflow {
-    __kind: 'Overflow'
-}
-
-export interface ArithmeticError_DivisionByZero {
-    __kind: 'DivisionByZero'
-}
-
-export type TransactionalError = TransactionalError_LimitReached | TransactionalError_NoLayer
-
-export interface TransactionalError_LimitReached {
-    __kind: 'LimitReached'
-}
-
-export interface TransactionalError_NoLayer {
-    __kind: 'NoLayer'
-}
-
-export type DispatchClass = DispatchClass_Normal | DispatchClass_Operational | DispatchClass_Mandatory
-
-export interface DispatchClass_Normal {
-    __kind: 'Normal'
-}
-
-export interface DispatchClass_Operational {
-    __kind: 'Operational'
-}
-
-export interface DispatchClass_Mandatory {
-    __kind: 'Mandatory'
-}
-
-export type Pays = Pays_Yes | Pays_No
-
-export interface Pays_Yes {
-    __kind: 'Yes'
-}
-
-export interface Pays_No {
-    __kind: 'No'
-}
-
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type SystemCall = SystemCall_remark | SystemCall_set_heap_pages | SystemCall_set_code | SystemCall_set_code_without_checks | SystemCall_set_storage | SystemCall_kill_storage | SystemCall_kill_prefix | SystemCall_remark_with_event
 
 /**
- * Make some on-chain remark.
- * 
- * ## Complexity
- * - `O(1)`
+ * See [`Pallet::remark`].
  */
 export interface SystemCall_remark {
     __kind: 'remark'
@@ -304,7 +119,7 @@ export interface SystemCall_remark {
 }
 
 /**
- * Set the number of pages in the WebAssembly environment's heap.
+ * See [`Pallet::set_heap_pages`].
  */
 export interface SystemCall_set_heap_pages {
     __kind: 'set_heap_pages'
@@ -312,10 +127,7 @@ export interface SystemCall_set_heap_pages {
 }
 
 /**
- * Set the new runtime code.
- * 
- * ## Complexity
- * - `O(C + S)` where `C` length of `code` and `S` complexity of `can_set_code`
+ * See [`Pallet::set_code`].
  */
 export interface SystemCall_set_code {
     __kind: 'set_code'
@@ -323,10 +135,7 @@ export interface SystemCall_set_code {
 }
 
 /**
- * Set the new runtime code without doing any checks of the given `code`.
- * 
- * ## Complexity
- * - `O(C)` where `C` length of `code`
+ * See [`Pallet::set_code_without_checks`].
  */
 export interface SystemCall_set_code_without_checks {
     __kind: 'set_code_without_checks'
@@ -334,7 +143,7 @@ export interface SystemCall_set_code_without_checks {
 }
 
 /**
- * Set some items of storage.
+ * See [`Pallet::set_storage`].
  */
 export interface SystemCall_set_storage {
     __kind: 'set_storage'
@@ -342,7 +151,7 @@ export interface SystemCall_set_storage {
 }
 
 /**
- * Kill some items from storage.
+ * See [`Pallet::kill_storage`].
  */
 export interface SystemCall_kill_storage {
     __kind: 'kill_storage'
@@ -350,10 +159,7 @@ export interface SystemCall_kill_storage {
 }
 
 /**
- * Kill all storage items with a key that starts with the given prefix.
- * 
- * **NOTE:** We rely on the Root origin to provide us the number of subkeys under
- * the prefix we are removing to accurately calculate the weight of this function.
+ * See [`Pallet::kill_prefix`].
  */
 export interface SystemCall_kill_prefix {
     __kind: 'kill_prefix'
@@ -362,7 +168,7 @@ export interface SystemCall_kill_prefix {
 }
 
 /**
- * Make some on-chain remark and emit event.
+ * See [`Pallet::remark_with_event`].
  */
 export interface SystemCall_remark_with_event {
     __kind: 'remark_with_event'
@@ -370,26 +176,12 @@ export interface SystemCall_remark_with_event {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type TimestampCall = TimestampCall_set
 
 /**
- * Set the current time.
- * 
- * This call should be invoked exactly once per block. It will panic at the finalization
- * phase, if this call hasn't been invoked by that time.
- * 
- * The timestamp should be greater than the previous one by the amount specified by
- * `MinimumPeriod`.
- * 
- * The dispatch origin for this call must be `Inherent`.
- * 
- * ## Complexity
- * - `O(1)` (Note that implementations of `OnTimestampSet` must also be `O(1)`)
- * - 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in
- *   `on_finalize`)
- * - 1 event handler `on_timestamp_set`. Must be `O(1)`.
+ * See [`Pallet::set`].
  */
 export interface TimestampCall_set {
     __kind: 'set'
@@ -397,17 +189,12 @@ export interface TimestampCall_set {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type SubspaceCall = SubspaceCall_report_equivocation | SubspaceCall_store_segment_headers | SubspaceCall_enable_solution_range_adjustment | SubspaceCall_vote | SubspaceCall_enable_rewards | SubspaceCall_enable_storage_access | SubspaceCall_enable_authoring_by_anyone
 
 /**
- * Report farmer equivocation/misbehavior. This method will verify the equivocation proof.
- * If valid, the offence will be reported.
- * 
- * This extrinsic must be called unsigned and it is expected that only block authors will
- * call it (validated in `ValidateUnsigned`), as such if the block author is defined it
- * will be defined as the equivocation reporter.
+ * See [`Pallet::report_equivocation`].
  */
 export interface SubspaceCall_report_equivocation {
     __kind: 'report_equivocation'
@@ -415,8 +202,7 @@ export interface SubspaceCall_report_equivocation {
 }
 
 /**
- * Submit new segment header to the blockchain. This is an inherent extrinsic and part of
- * the Subspace consensus logic.
+ * See [`Pallet::store_segment_headers`].
  */
 export interface SubspaceCall_store_segment_headers {
     __kind: 'store_segment_headers'
@@ -424,8 +210,7 @@ export interface SubspaceCall_store_segment_headers {
 }
 
 /**
- * Enable solution range adjustment after every era.
- * Note: No effect on the solution range for the current era
+ * See [`Pallet::enable_solution_range_adjustment`].
  */
 export interface SubspaceCall_enable_solution_range_adjustment {
     __kind: 'enable_solution_range_adjustment'
@@ -434,7 +219,7 @@ export interface SubspaceCall_enable_solution_range_adjustment {
 }
 
 /**
- * Farmer vote, currently only used for extra rewards to farmers.
+ * See [`Pallet::vote`].
  */
 export interface SubspaceCall_vote {
     __kind: 'vote'
@@ -442,7 +227,7 @@ export interface SubspaceCall_vote {
 }
 
 /**
- * Enable rewards for blocks and votes at specified block height.
+ * See [`Pallet::enable_rewards`].
  */
 export interface SubspaceCall_enable_rewards {
     __kind: 'enable_rewards'
@@ -450,32 +235,26 @@ export interface SubspaceCall_enable_rewards {
 }
 
 /**
- * Enable storage access for all users.
+ * See [`Pallet::enable_storage_access`].
  */
 export interface SubspaceCall_enable_storage_access {
     __kind: 'enable_storage_access'
 }
 
 /**
- * Enable storage access for all users.
+ * See [`Pallet::enable_authoring_by_anyone`].
  */
 export interface SubspaceCall_enable_authoring_by_anyone {
     __kind: 'enable_authoring_by_anyone'
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type BalancesCall = BalancesCall_transfer_allow_death | BalancesCall_set_balance_deprecated | BalancesCall_force_transfer | BalancesCall_transfer_keep_alive | BalancesCall_transfer_all | BalancesCall_force_unreserve | BalancesCall_upgrade_accounts | BalancesCall_transfer | BalancesCall_force_set_balance
 
 /**
- * Transfer some liquid free balance to another account.
- * 
- * `transfer_allow_death` will set the `FreeBalance` of the sender and receiver.
- * If the sender's account is below the existential deposit as a result
- * of the transfer, the account will be reaped.
- * 
- * The dispatch origin for this call must be `Signed` by the transactor.
+ * See [`Pallet::transfer_allow_death`].
  */
 export interface BalancesCall_transfer_allow_death {
     __kind: 'transfer_allow_death'
@@ -484,12 +263,7 @@ export interface BalancesCall_transfer_allow_death {
 }
 
 /**
- * Set the regular balance of a given account; it also takes a reserved balance but this
- * must be the same as the account's current reserved balance.
- * 
- * The dispatch origin for this call is `root`.
- * 
- * WARNING: This call is DEPRECATED! Use `force_set_balance` instead.
+ * See [`Pallet::set_balance_deprecated`].
  */
 export interface BalancesCall_set_balance_deprecated {
     __kind: 'set_balance_deprecated'
@@ -499,8 +273,7 @@ export interface BalancesCall_set_balance_deprecated {
 }
 
 /**
- * Exactly as `transfer_allow_death`, except the origin must be root and the source account
- * may be specified.
+ * See [`Pallet::force_transfer`].
  */
 export interface BalancesCall_force_transfer {
     __kind: 'force_transfer'
@@ -510,12 +283,7 @@ export interface BalancesCall_force_transfer {
 }
 
 /**
- * Same as the [`transfer_allow_death`] call, but with a check that the transfer will not
- * kill the origin account.
- * 
- * 99% of the time you want [`transfer_allow_death`] instead.
- * 
- * [`transfer_allow_death`]: struct.Pallet.html#method.transfer
+ * See [`Pallet::transfer_keep_alive`].
  */
 export interface BalancesCall_transfer_keep_alive {
     __kind: 'transfer_keep_alive'
@@ -524,21 +292,7 @@ export interface BalancesCall_transfer_keep_alive {
 }
 
 /**
- * Transfer the entire transferable balance from the caller account.
- * 
- * NOTE: This function only attempts to transfer _transferable_ balances. This means that
- * any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be
- * transferred by this function. To ensure that this function results in a killed account,
- * you might need to prepare the account by removing any reference counters, storage
- * deposits, etc...
- * 
- * The dispatch origin of this call must be Signed.
- * 
- * - `dest`: The recipient of the transfer.
- * - `keep_alive`: A boolean to determine if the `transfer_all` operation should send all
- *   of the funds the account has, causing the sender account to be killed (false), or
- *   transfer everything except at least the existential deposit, which will guarantee to
- *   keep the sender account alive (true).
+ * See [`Pallet::transfer_all`].
  */
 export interface BalancesCall_transfer_all {
     __kind: 'transfer_all'
@@ -547,9 +301,7 @@ export interface BalancesCall_transfer_all {
 }
 
 /**
- * Unreserve some balance from a user by force.
- * 
- * Can only be called by ROOT.
+ * See [`Pallet::force_unreserve`].
  */
 export interface BalancesCall_force_unreserve {
     __kind: 'force_unreserve'
@@ -558,14 +310,7 @@ export interface BalancesCall_force_unreserve {
 }
 
 /**
- * Upgrade a specified account.
- * 
- * - `origin`: Must be `Signed`.
- * - `who`: The account to be upgraded.
- * 
- * This will waive the transaction fee if at least all but 10% of the accounts needed to
- * be upgraded. (We let some not have to be upgraded just in order to allow for the
- * possibililty of churn).
+ * See [`Pallet::upgrade_accounts`].
  */
 export interface BalancesCall_upgrade_accounts {
     __kind: 'upgrade_accounts'
@@ -573,9 +318,7 @@ export interface BalancesCall_upgrade_accounts {
 }
 
 /**
- * Alias for `transfer_allow_death`, provided only for name-wise compatibility.
- * 
- * WARNING: DEPRECATED! Will be released in approximately 3 months.
+ * See [`Pallet::transfer`].
  */
 export interface BalancesCall_transfer {
     __kind: 'transfer'
@@ -584,9 +327,7 @@ export interface BalancesCall_transfer {
 }
 
 /**
- * Set the regular balance of a given account.
- * 
- * The dispatch origin for this call is `root`.
+ * See [`Pallet::force_set_balance`].
  */
 export interface BalancesCall_force_set_balance {
     __kind: 'force_set_balance'
@@ -595,29 +336,12 @@ export interface BalancesCall_force_set_balance {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type UtilityCall = UtilityCall_batch | UtilityCall_as_derivative | UtilityCall_batch_all | UtilityCall_dispatch_as | UtilityCall_force_batch | UtilityCall_with_weight
 
 /**
- * Send a batch of dispatch calls.
- * 
- * May be called from any origin except `None`.
- * 
- * - `calls`: The calls to be dispatched from the same origin. The number of call must not
- *   exceed the constant: `batched_calls_limit` (available in constant metadata).
- * 
- * If origin is root then the calls are dispatched without checking origin filter. (This
- * includes bypassing `frame_system::Config::BaseCallFilter`).
- * 
- * ## Complexity
- * - O(C) where C is the number of calls to be batched.
- * 
- * This will return `Ok` in all circumstances. To determine the success of the batch, an
- * event is deposited. If a call failed and the batch was interrupted, then the
- * `BatchInterrupted` event is deposited, along with the number of successful calls made
- * and the error of the failed call. If all were successful, then the `BatchCompleted`
- * event is deposited.
+ * See [`Pallet::batch`].
  */
 export interface UtilityCall_batch {
     __kind: 'batch'
@@ -625,19 +349,7 @@ export interface UtilityCall_batch {
 }
 
 /**
- * Send a call through an indexed pseudonym of the sender.
- * 
- * Filter from origin are passed along. The call will be dispatched with an origin which
- * use the same filter as the origin of this call.
- * 
- * NOTE: If you need to ensure that any account-based filtering is not honored (i.e.
- * because you expect `proxy` to have been used prior in the call stack and you do not want
- * the call restrictions to apply to any sub-accounts), then use `as_multi_threshold_1`
- * in the Multisig pallet instead.
- * 
- * NOTE: Prior to version *12, this was called `as_limited_sub`.
- * 
- * The dispatch origin for this call must be _Signed_.
+ * See [`Pallet::as_derivative`].
  */
 export interface UtilityCall_as_derivative {
     __kind: 'as_derivative'
@@ -646,19 +358,7 @@ export interface UtilityCall_as_derivative {
 }
 
 /**
- * Send a batch of dispatch calls and atomically execute them.
- * The whole transaction will rollback and fail if any of the calls failed.
- * 
- * May be called from any origin except `None`.
- * 
- * - `calls`: The calls to be dispatched from the same origin. The number of call must not
- *   exceed the constant: `batched_calls_limit` (available in constant metadata).
- * 
- * If origin is root then the calls are dispatched without checking origin filter. (This
- * includes bypassing `frame_system::Config::BaseCallFilter`).
- * 
- * ## Complexity
- * - O(C) where C is the number of calls to be batched.
+ * See [`Pallet::batch_all`].
  */
 export interface UtilityCall_batch_all {
     __kind: 'batch_all'
@@ -666,12 +366,7 @@ export interface UtilityCall_batch_all {
 }
 
 /**
- * Dispatches a function call with a provided origin.
- * 
- * The dispatch origin for this call must be _Root_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::dispatch_as`].
  */
 export interface UtilityCall_dispatch_as {
     __kind: 'dispatch_as'
@@ -680,19 +375,7 @@ export interface UtilityCall_dispatch_as {
 }
 
 /**
- * Send a batch of dispatch calls.
- * Unlike `batch`, it allows errors and won't interrupt.
- * 
- * May be called from any origin except `None`.
- * 
- * - `calls`: The calls to be dispatched from the same origin. The number of call must not
- *   exceed the constant: `batched_calls_limit` (available in constant metadata).
- * 
- * If origin is root then the calls are dispatch without checking origin filter. (This
- * includes bypassing `frame_system::Config::BaseCallFilter`).
- * 
- * ## Complexity
- * - O(C) where C is the number of calls to be batched.
+ * See [`Pallet::force_batch`].
  */
 export interface UtilityCall_force_batch {
     __kind: 'force_batch'
@@ -700,12 +383,7 @@ export interface UtilityCall_force_batch {
 }
 
 /**
- * Dispatch a function call with a specified weight.
- * 
- * This function does not check the weight of the call, and instead allows the
- * Root origin to specify the weight of the call.
- * 
- * The dispatch origin for this call must be _Root_.
+ * See [`Pallet::with_weight`].
  */
 export interface UtilityCall_with_weight {
     __kind: 'with_weight'
@@ -714,12 +392,12 @@ export interface UtilityCall_with_weight {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type FeedsCall = FeedsCall_create | FeedsCall_update | FeedsCall_put | FeedsCall_close | FeedsCall_transfer
 
 /**
- * Create a new feed
+ * See [`Pallet::create`].
  */
 export interface FeedsCall_create {
     __kind: 'create'
@@ -728,7 +406,7 @@ export interface FeedsCall_create {
 }
 
 /**
- * Updates the feed with init data provided.
+ * See [`Pallet::update`].
  */
 export interface FeedsCall_update {
     __kind: 'update'
@@ -738,7 +416,7 @@ export interface FeedsCall_update {
 }
 
 /**
- * Put a new object into a feed
+ * See [`Pallet::put`].
  */
 export interface FeedsCall_put {
     __kind: 'put'
@@ -747,7 +425,7 @@ export interface FeedsCall_put {
 }
 
 /**
- * Closes the feed and stops accepting new feed.
+ * See [`Pallet::close`].
  */
 export interface FeedsCall_close {
     __kind: 'close'
@@ -755,7 +433,7 @@ export interface FeedsCall_close {
 }
 
 /**
- * Transfers feed from current owner to new owner
+ * See [`Pallet::transfer`].
  */
 export interface FeedsCall_transfer {
     __kind: 'transfer'
@@ -764,12 +442,12 @@ export interface FeedsCall_transfer {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type ObjectStoreCall = ObjectStoreCall_put
 
 /**
- * Put a new object into a feed
+ * See [`Pallet::put`].
  */
 export interface ObjectStoreCall_put {
     __kind: 'put'
@@ -777,68 +455,152 @@ export interface ObjectStoreCall_put {
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
-export type DomainsCall = DomainsCall_submit_bundle | DomainsCall_submit_fraud_proof | DomainsCall_submit_bundle_equivocation_proof | DomainsCall_submit_invalid_transaction_proof
+export type DomainsCall = DomainsCall_submit_bundle | DomainsCall_submit_fraud_proof | DomainsCall_register_domain_runtime | DomainsCall_upgrade_domain_runtime | DomainsCall_register_operator | DomainsCall_nominate_operator | DomainsCall_instantiate_domain | DomainsCall_switch_domain | DomainsCall_deregister_operator | DomainsCall_withdraw_stake | DomainsCall_auto_stake_block_rewards
 
+/**
+ * See [`Pallet::submit_bundle`].
+ */
 export interface DomainsCall_submit_bundle {
     __kind: 'submit_bundle'
-    signedOpaqueBundle: SignedBundle
+    opaqueBundle: Bundle
 }
 
+/**
+ * See [`Pallet::submit_fraud_proof`].
+ */
 export interface DomainsCall_submit_fraud_proof {
     __kind: 'submit_fraud_proof'
     fraudProof: FraudProof
 }
 
-export interface DomainsCall_submit_bundle_equivocation_proof {
-    __kind: 'submit_bundle_equivocation_proof'
-    bundleEquivocationProof: BundleEquivocationProof
-}
-
-export interface DomainsCall_submit_invalid_transaction_proof {
-    __kind: 'submit_invalid_transaction_proof'
-    invalidTransactionProof: InvalidTransactionProof
+/**
+ * See [`Pallet::register_domain_runtime`].
+ */
+export interface DomainsCall_register_domain_runtime {
+    __kind: 'register_domain_runtime'
+    runtimeName: Uint8Array
+    runtimeType: RuntimeType
+    code: Uint8Array
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * See [`Pallet::upgrade_domain_runtime`].
+ */
+export interface DomainsCall_upgrade_domain_runtime {
+    __kind: 'upgrade_domain_runtime'
+    runtimeId: number
+    code: Uint8Array
+}
+
+/**
+ * See [`Pallet::register_operator`].
+ */
+export interface DomainsCall_register_operator {
+    __kind: 'register_operator'
+    domainId: number
+    amount: bigint
+    config: OperatorConfig
+}
+
+/**
+ * See [`Pallet::nominate_operator`].
+ */
+export interface DomainsCall_nominate_operator {
+    __kind: 'nominate_operator'
+    operatorId: bigint
+    amount: bigint
+}
+
+/**
+ * See [`Pallet::instantiate_domain`].
+ */
+export interface DomainsCall_instantiate_domain {
+    __kind: 'instantiate_domain'
+    domainConfig: DomainConfig
+    rawGenesis: Uint8Array
+}
+
+/**
+ * See [`Pallet::switch_domain`].
+ */
+export interface DomainsCall_switch_domain {
+    __kind: 'switch_domain'
+    operatorId: bigint
+    newDomainId: number
+}
+
+/**
+ * See [`Pallet::deregister_operator`].
+ */
+export interface DomainsCall_deregister_operator {
+    __kind: 'deregister_operator'
+    operatorId: bigint
+}
+
+/**
+ * See [`Pallet::withdraw_stake`].
+ */
+export interface DomainsCall_withdraw_stake {
+    __kind: 'withdraw_stake'
+    operatorId: bigint
+    withdraw: Withdraw
+}
+
+/**
+ * See [`Pallet::auto_stake_block_rewards`].
+ */
+export interface DomainsCall_auto_stake_block_rewards {
+    __kind: 'auto_stake_block_rewards'
+    operatorId: bigint
+}
+
+/**
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type VestingCall = VestingCall_claim | VestingCall_vested_transfer | VestingCall_update_vesting_schedules | VestingCall_claim_for
 
+/**
+ * See [`Pallet::claim`].
+ */
 export interface VestingCall_claim {
     __kind: 'claim'
 }
 
+/**
+ * See [`Pallet::vested_transfer`].
+ */
 export interface VestingCall_vested_transfer {
     __kind: 'vested_transfer'
     dest: MultiAddress
     schedule: VestingSchedule
 }
 
+/**
+ * See [`Pallet::update_vesting_schedules`].
+ */
 export interface VestingCall_update_vesting_schedules {
     __kind: 'update_vesting_schedules'
     who: MultiAddress
     vestingSchedules: VestingSchedule[]
 }
 
+/**
+ * See [`Pallet::claim_for`].
+ */
 export interface VestingCall_claim_for {
     __kind: 'claim_for'
     dest: MultiAddress
 }
 
 /**
- * Contains one variant per dispatchable that can be called by an extrinsic.
+ * Contains a variant per dispatchable extrinsic that this pallet has.
  */
 export type SudoCall = SudoCall_sudo | SudoCall_sudo_unchecked_weight | SudoCall_set_key | SudoCall_sudo_as
 
 /**
- * Authenticates the sudo key and dispatches a function call with `Root` origin.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::sudo`].
  */
 export interface SudoCall_sudo {
     __kind: 'sudo'
@@ -846,14 +608,7 @@ export interface SudoCall_sudo {
 }
 
 /**
- * Authenticates the sudo key and dispatches a function call with `Root` origin.
- * This function does not check the weight of the call, and instead allows the
- * Sudo user to specify the weight of the call.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::sudo_unchecked_weight`].
  */
 export interface SudoCall_sudo_unchecked_weight {
     __kind: 'sudo_unchecked_weight'
@@ -862,13 +617,7 @@ export interface SudoCall_sudo_unchecked_weight {
 }
 
 /**
- * Authenticates the current sudo key and sets the given AccountId (`new`) as the new sudo
- * key.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::set_key`].
  */
 export interface SudoCall_set_key {
     __kind: 'set_key'
@@ -876,13 +625,7 @@ export interface SudoCall_set_key {
 }
 
 /**
- * Authenticates the sudo key and dispatches a function call with `Signed` origin from
- * a given account.
- * 
- * The dispatch origin for this call must be _Signed_.
- * 
- * ## Complexity
- * - O(1).
+ * See [`Pallet::sudo_as`].
  */
 export interface SudoCall_sudo_as {
     __kind: 'sudo_as'
@@ -906,93 +649,6 @@ export interface RawOrigin_None {
 }
 
 export type Void = never
-
-export type Phase = Phase_ApplyExtrinsic | Phase_Finalization | Phase_Initialization
-
-export interface Phase_ApplyExtrinsic {
-    __kind: 'ApplyExtrinsic'
-    value: number
-}
-
-export interface Phase_Finalization {
-    __kind: 'Finalization'
-}
-
-export interface Phase_Initialization {
-    __kind: 'Initialization'
-}
-
-export type Event = Event_System | Event_Subspace | Event_OffencesSubspace | Event_Rewards | Event_Balances | Event_TransactionFees | Event_TransactionPayment | Event_Utility | Event_Feeds | Event_ObjectStore | Event_Receipts | Event_Domains | Event_Vesting | Event_Sudo
-
-export interface Event_System {
-    __kind: 'System'
-    value: SystemEvent
-}
-
-export interface Event_Subspace {
-    __kind: 'Subspace'
-    value: SubspaceEvent
-}
-
-export interface Event_OffencesSubspace {
-    __kind: 'OffencesSubspace'
-    value: OffencesSubspaceEvent
-}
-
-export interface Event_Rewards {
-    __kind: 'Rewards'
-    value: RewardsEvent
-}
-
-export interface Event_Balances {
-    __kind: 'Balances'
-    value: BalancesEvent
-}
-
-export interface Event_TransactionFees {
-    __kind: 'TransactionFees'
-    value: TransactionFeesEvent
-}
-
-export interface Event_TransactionPayment {
-    __kind: 'TransactionPayment'
-    value: TransactionPaymentEvent
-}
-
-export interface Event_Utility {
-    __kind: 'Utility'
-    value: UtilityEvent
-}
-
-export interface Event_Feeds {
-    __kind: 'Feeds'
-    value: FeedsEvent
-}
-
-export interface Event_ObjectStore {
-    __kind: 'ObjectStore'
-    value: ObjectStoreEvent
-}
-
-export interface Event_Receipts {
-    __kind: 'Receipts'
-    value: ReceiptsEvent
-}
-
-export interface Event_Domains {
-    __kind: 'Domains'
-    value: DomainsEvent
-}
-
-export interface Event_Vesting {
-    __kind: 'Vesting'
-    value: VestingEvent
-}
-
-export interface Event_Sudo {
-    __kind: 'Sudo'
-    value: SudoEvent
-}
 
 export interface EquivocationProof {
     offender: Uint8Array
@@ -1030,10 +686,9 @@ export interface FeedProcessorKind_ParachainLike {
     __kind: 'ParachainLike'
 }
 
-export interface SignedBundle {
-    bundle: Bundle
-    bundleSolution: BundleSolution
-    signature: Uint8Array
+export interface Bundle {
+    sealedHeader: SealedBundleHeader
+    extrinsics: Uint8Array[]
 }
 
 export type FraudProof = FraudProof_InvalidStateTransition | FraudProof_InvalidTransaction | FraudProof_BundleEquivocation | FraudProof_ImproperTransactionSortition
@@ -1058,16 +713,27 @@ export interface FraudProof_ImproperTransactionSortition {
     value: ImproperTransactionSortitionProof
 }
 
-export interface BundleEquivocationProof {
-    domainId: number
-    offender: Uint8Array
-    slot: bigint
-    firstHeader: BundleHeader
-    secondHeader: BundleHeader
+export type RuntimeType = RuntimeType_Evm
+
+export interface RuntimeType_Evm {
+    __kind: 'Evm'
 }
 
-export interface InvalidTransactionProof {
-    domainId: number
+export interface OperatorConfig {
+    signingKey: Uint8Array
+    minimumNominatorStake: bigint
+    nominationTax: number
+}
+
+export type Withdraw = Withdraw_All | Withdraw_Some
+
+export interface Withdraw_All {
+    __kind: 'All'
+}
+
+export interface Withdraw_Some {
+    __kind: 'Some'
+    value: bigint
 }
 
 export interface VestingSchedule {
@@ -1075,647 +741,6 @@ export interface VestingSchedule {
     period: number
     periodCount: number
     perPeriod: bigint
-}
-
-/**
- * Event for the System pallet.
- */
-export type SystemEvent = SystemEvent_ExtrinsicSuccess | SystemEvent_ExtrinsicFailed | SystemEvent_CodeUpdated | SystemEvent_NewAccount | SystemEvent_KilledAccount | SystemEvent_Remarked
-
-/**
- * An extrinsic completed successfully.
- */
-export interface SystemEvent_ExtrinsicSuccess {
-    __kind: 'ExtrinsicSuccess'
-    dispatchInfo: DispatchInfo
-}
-
-/**
- * An extrinsic failed.
- */
-export interface SystemEvent_ExtrinsicFailed {
-    __kind: 'ExtrinsicFailed'
-    dispatchError: DispatchError
-    dispatchInfo: DispatchInfo
-}
-
-/**
- * `:code` was updated.
- */
-export interface SystemEvent_CodeUpdated {
-    __kind: 'CodeUpdated'
-}
-
-/**
- * A new account was created.
- */
-export interface SystemEvent_NewAccount {
-    __kind: 'NewAccount'
-    account: Uint8Array
-}
-
-/**
- * An account was reaped.
- */
-export interface SystemEvent_KilledAccount {
-    __kind: 'KilledAccount'
-    account: Uint8Array
-}
-
-/**
- * On on-chain remark happened.
- */
-export interface SystemEvent_Remarked {
-    __kind: 'Remarked'
-    sender: Uint8Array
-    hash: Uint8Array
-}
-
-/**
- * Events type.
- */
-export type SubspaceEvent = SubspaceEvent_SegmentHeaderStored | SubspaceEvent_FarmerVote
-
-/**
- * Segment header was stored in blockchain history.
- */
-export interface SubspaceEvent_SegmentHeaderStored {
-    __kind: 'SegmentHeaderStored'
-    segmentHeader: SegmentHeader
-}
-
-/**
- * Farmer vote.
- */
-export interface SubspaceEvent_FarmerVote {
-    __kind: 'FarmerVote'
-    publicKey: Uint8Array
-    rewardAddress: Uint8Array
-    height: number
-    parentHash: Uint8Array
-}
-
-/**
- * Events type.
- */
-export type OffencesSubspaceEvent = OffencesSubspaceEvent_Offence
-
-/**
- * There is an offence reported of the given `kind` happened at the `session_index` and
- * (kind-specific) time slot. This event is not deposited for duplicate slashes.
- * \[kind, timeslot\].
- */
-export interface OffencesSubspaceEvent_Offence {
-    __kind: 'Offence'
-    kind: Uint8Array
-    timeslot: Uint8Array
-}
-
-/**
- * `pallet-rewards` events
- */
-export type RewardsEvent = RewardsEvent_BlockReward | RewardsEvent_VoteReward
-
-/**
- * Issued reward for the block author.
- */
-export interface RewardsEvent_BlockReward {
-    __kind: 'BlockReward'
-    blockAuthor: Uint8Array
-    reward: bigint
-}
-
-/**
- * Issued reward for the voter.
- */
-export interface RewardsEvent_VoteReward {
-    __kind: 'VoteReward'
-    voter: Uint8Array
-    reward: bigint
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type BalancesEvent = BalancesEvent_Endowed | BalancesEvent_DustLost | BalancesEvent_Transfer | BalancesEvent_BalanceSet | BalancesEvent_Reserved | BalancesEvent_Unreserved | BalancesEvent_ReserveRepatriated | BalancesEvent_Deposit | BalancesEvent_Withdraw | BalancesEvent_Slashed | BalancesEvent_Minted | BalancesEvent_Burned | BalancesEvent_Suspended | BalancesEvent_Restored | BalancesEvent_Upgraded | BalancesEvent_Issued | BalancesEvent_Rescinded | BalancesEvent_Locked | BalancesEvent_Unlocked
-
-/**
- * An account was created with some free balance.
- */
-export interface BalancesEvent_Endowed {
-    __kind: 'Endowed'
-    account: Uint8Array
-    freeBalance: bigint
-}
-
-/**
- * An account was removed whose balance was non-zero but below ExistentialDeposit,
- * resulting in an outright loss.
- */
-export interface BalancesEvent_DustLost {
-    __kind: 'DustLost'
-    account: Uint8Array
-    amount: bigint
-}
-
-/**
- * Transfer succeeded.
- */
-export interface BalancesEvent_Transfer {
-    __kind: 'Transfer'
-    from: Uint8Array
-    to: Uint8Array
-    amount: bigint
-}
-
-/**
- * A balance was set by root.
- */
-export interface BalancesEvent_BalanceSet {
-    __kind: 'BalanceSet'
-    who: Uint8Array
-    free: bigint
-}
-
-/**
- * Some balance was reserved (moved from free to reserved).
- */
-export interface BalancesEvent_Reserved {
-    __kind: 'Reserved'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some balance was unreserved (moved from reserved to free).
- */
-export interface BalancesEvent_Unreserved {
-    __kind: 'Unreserved'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some balance was moved from the reserve of the first account to the second account.
- * Final argument indicates the destination balance type.
- */
-export interface BalancesEvent_ReserveRepatriated {
-    __kind: 'ReserveRepatriated'
-    from: Uint8Array
-    to: Uint8Array
-    amount: bigint
-    destinationStatus: BalanceStatus
-}
-
-/**
- * Some amount was deposited (e.g. for transaction fees).
- */
-export interface BalancesEvent_Deposit {
-    __kind: 'Deposit'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some amount was withdrawn from the account (e.g. for transaction fees).
- */
-export interface BalancesEvent_Withdraw {
-    __kind: 'Withdraw'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some amount was removed from the account (e.g. for misbehavior).
- */
-export interface BalancesEvent_Slashed {
-    __kind: 'Slashed'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some amount was minted into an account.
- */
-export interface BalancesEvent_Minted {
-    __kind: 'Minted'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some amount was burned from an account.
- */
-export interface BalancesEvent_Burned {
-    __kind: 'Burned'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some amount was suspended from an account (it can be restored later).
- */
-export interface BalancesEvent_Suspended {
-    __kind: 'Suspended'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some amount was restored into an account.
- */
-export interface BalancesEvent_Restored {
-    __kind: 'Restored'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * An account was upgraded.
- */
-export interface BalancesEvent_Upgraded {
-    __kind: 'Upgraded'
-    who: Uint8Array
-}
-
-/**
- * Total issuance was increased by `amount`, creating a credit to be balanced.
- */
-export interface BalancesEvent_Issued {
-    __kind: 'Issued'
-    amount: bigint
-}
-
-/**
- * Total issuance was decreased by `amount`, creating a debt to be balanced.
- */
-export interface BalancesEvent_Rescinded {
-    __kind: 'Rescinded'
-    amount: bigint
-}
-
-/**
- * Some balance was locked.
- */
-export interface BalancesEvent_Locked {
-    __kind: 'Locked'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Some balance was unlocked.
- */
-export interface BalancesEvent_Unlocked {
-    __kind: 'Unlocked'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * `pallet-transaction-fees` events
- */
-export type TransactionFeesEvent = TransactionFeesEvent_StorageFeesEscrowChange | TransactionFeesEvent_StorageFeesReward | TransactionFeesEvent_ComputeFeesReward | TransactionFeesEvent_TipsReward
-
-/**
- * Storage fees escrow change.
- */
-export interface TransactionFeesEvent_StorageFeesEscrowChange {
-    __kind: 'StorageFeesEscrowChange'
-    /**
-     * State of storage fees escrow before block execution.
-     */
-    before: bigint
-    /**
-     * State of storage fees escrow after block execution.
-     */
-    after: bigint
-}
-
-/**
- * Storage fees.
- */
-export interface TransactionFeesEvent_StorageFeesReward {
-    __kind: 'StorageFeesReward'
-    /**
-     * Receiver of the storage fees.
-     */
-    who: Uint8Array
-    /**
-     * Amount of collected storage fees.
-     */
-    amount: bigint
-}
-
-/**
- * Compute fees.
- */
-export interface TransactionFeesEvent_ComputeFeesReward {
-    __kind: 'ComputeFeesReward'
-    /**
-     * Receiver of the compute fees.
-     */
-    who: Uint8Array
-    /**
-     * Amount of collected compute fees.
-     */
-    amount: bigint
-}
-
-/**
- * Tips.
- */
-export interface TransactionFeesEvent_TipsReward {
-    __kind: 'TipsReward'
-    /**
-     * Receiver of the tip.
-     */
-    who: Uint8Array
-    /**
-     * Amount of collected tips.
-     */
-    amount: bigint
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type TransactionPaymentEvent = TransactionPaymentEvent_TransactionFeePaid
-
-/**
- * A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,
- * has been paid by `who`.
- */
-export interface TransactionPaymentEvent_TransactionFeePaid {
-    __kind: 'TransactionFeePaid'
-    who: Uint8Array
-    actualFee: bigint
-    tip: bigint
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type UtilityEvent = UtilityEvent_BatchInterrupted | UtilityEvent_BatchCompleted | UtilityEvent_BatchCompletedWithErrors | UtilityEvent_ItemCompleted | UtilityEvent_ItemFailed | UtilityEvent_DispatchedAs
-
-/**
- * Batch of dispatches did not complete fully. Index of first failing dispatch given, as
- * well as the error.
- */
-export interface UtilityEvent_BatchInterrupted {
-    __kind: 'BatchInterrupted'
-    index: number
-    error: DispatchError
-}
-
-/**
- * Batch of dispatches completed fully with no error.
- */
-export interface UtilityEvent_BatchCompleted {
-    __kind: 'BatchCompleted'
-}
-
-/**
- * Batch of dispatches completed but has errors.
- */
-export interface UtilityEvent_BatchCompletedWithErrors {
-    __kind: 'BatchCompletedWithErrors'
-}
-
-/**
- * A single item within a Batch of dispatches has completed with no error.
- */
-export interface UtilityEvent_ItemCompleted {
-    __kind: 'ItemCompleted'
-}
-
-/**
- * A single item within a Batch of dispatches has completed with error.
- */
-export interface UtilityEvent_ItemFailed {
-    __kind: 'ItemFailed'
-    error: DispatchError
-}
-
-/**
- * A call was dispatched.
- */
-export interface UtilityEvent_DispatchedAs {
-    __kind: 'DispatchedAs'
-    result: Type_47
-}
-
-/**
- * `pallet-feeds` events
- */
-export type FeedsEvent = FeedsEvent_ObjectSubmitted | FeedsEvent_FeedCreated | FeedsEvent_FeedUpdated | FeedsEvent_FeedClosed | FeedsEvent_FeedDeleted | FeedsEvent_OwnershipTransferred
-
-/**
- * New object was added.
- */
-export interface FeedsEvent_ObjectSubmitted {
-    __kind: 'ObjectSubmitted'
-    feedId: bigint
-    who: Uint8Array
-    metadata: Uint8Array
-    objectSize: bigint
-}
-
-/**
- * New feed was created.
- */
-export interface FeedsEvent_FeedCreated {
-    __kind: 'FeedCreated'
-    feedId: bigint
-    who: Uint8Array
-}
-
-/**
- * An existing feed was updated.
- */
-export interface FeedsEvent_FeedUpdated {
-    __kind: 'FeedUpdated'
-    feedId: bigint
-    who: Uint8Array
-}
-
-/**
- * Feed was closed.
- */
-export interface FeedsEvent_FeedClosed {
-    __kind: 'FeedClosed'
-    feedId: bigint
-    who: Uint8Array
-}
-
-/**
- * Feed was deleted.
- */
-export interface FeedsEvent_FeedDeleted {
-    __kind: 'FeedDeleted'
-    feedId: bigint
-    who: Uint8Array
-}
-
-/**
- * feed ownership transferred
- */
-export interface FeedsEvent_OwnershipTransferred {
-    __kind: 'OwnershipTransferred'
-    feedId: bigint
-    oldOwner: Uint8Array
-    newOwner: Uint8Array
-}
-
-/**
- * `pallet-object-store` events
- */
-export type ObjectStoreEvent = ObjectStoreEvent_ObjectSubmitted
-
-/**
- * New object was added.
- */
-export interface ObjectStoreEvent_ObjectSubmitted {
-    __kind: 'ObjectSubmitted'
-    who: Uint8Array
-    objectId: Uint8Array
-    objectSize: number
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type ReceiptsEvent = ReceiptsEvent_NewDomainReceipt | ReceiptsEvent_FraudProofProcessed
-
-/**
- * A new domain receipt.
- */
-export interface ReceiptsEvent_NewDomainReceipt {
-    __kind: 'NewDomainReceipt'
-    domainId: number
-    primaryNumber: number
-    primaryHash: Uint8Array
-}
-
-/**
- * A fraud proof was processed.
- */
-export interface ReceiptsEvent_FraudProofProcessed {
-    __kind: 'FraudProofProcessed'
-    domainId: number
-    newBestNumber: number
-    newBestHash: Uint8Array
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type DomainsEvent = DomainsEvent_BundleStored | DomainsEvent_BundleEquivocationProofProcessed | DomainsEvent_InvalidTransactionProofProcessed
-
-/**
- * A domain bundle was included.
- */
-export interface DomainsEvent_BundleStored {
-    __kind: 'BundleStored'
-    domainId: number
-    bundleHash: Uint8Array
-    bundleAuthor: Uint8Array
-}
-
-/**
- * A bundle equivocation proof was processed.
- */
-export interface DomainsEvent_BundleEquivocationProofProcessed {
-    __kind: 'BundleEquivocationProofProcessed'
-}
-
-/**
- * An invalid transaction proof was processed.
- */
-export interface DomainsEvent_InvalidTransactionProofProcessed {
-    __kind: 'InvalidTransactionProofProcessed'
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type VestingEvent = VestingEvent_VestingScheduleAdded | VestingEvent_Claimed | VestingEvent_VestingSchedulesUpdated
-
-/**
- * Added new vesting schedule.
- */
-export interface VestingEvent_VestingScheduleAdded {
-    __kind: 'VestingScheduleAdded'
-    from: Uint8Array
-    to: Uint8Array
-    vestingSchedule: VestingSchedule
-}
-
-/**
- * Claimed vesting.
- */
-export interface VestingEvent_Claimed {
-    __kind: 'Claimed'
-    who: Uint8Array
-    amount: bigint
-}
-
-/**
- * Updated vesting schedules.
- */
-export interface VestingEvent_VestingSchedulesUpdated {
-    __kind: 'VestingSchedulesUpdated'
-    who: Uint8Array
-}
-
-/**
- * 
-			The [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted
-			by this pallet.
-			
- */
-export type SudoEvent = SudoEvent_Sudid | SudoEvent_KeyChanged | SudoEvent_SudoAsDone
-
-/**
- * A sudo just took place. \[result\]
- */
-export interface SudoEvent_Sudid {
-    __kind: 'Sudid'
-    sudoResult: Type_47
-}
-
-/**
- * The \[sudoer\] just switched identity; the old key is supplied if one existed.
- */
-export interface SudoEvent_KeyChanged {
-    __kind: 'KeyChanged'
-    oldSudoer: (Uint8Array | undefined)
-}
-
-/**
- * A sudo just took place. \[result\]
- */
-export interface SudoEvent_SudoAsDone {
-    __kind: 'SudoAsDone'
-    sudoResult: Type_47
 }
 
 export interface Header {
@@ -1745,59 +770,40 @@ export interface Vote_V0 {
     solution: Solution
 }
 
-export interface Bundle {
+export interface SealedBundleHeader {
     header: BundleHeader
-    receipts: ExecutionReceipt[]
-    extrinsics: Uint8Array[]
-}
-
-export type BundleSolution = BundleSolution_System | BundleSolution_Core
-
-export interface BundleSolution_System {
-    __kind: 'System'
-    authorityStakeWeight: bigint
-    authorityWitness: Type_158
-    proofOfElection: ProofOfElection
-}
-
-export interface BundleSolution_Core {
-    __kind: 'Core'
-    proofOfElection: ProofOfElection
-    coreBlockNumber: number
-    coreBlockHash: Uint8Array
-    coreStateRoot: Uint8Array
+    signature: Uint8Array
 }
 
 export interface InvalidStateTransitionProof {
     domainId: number
     badReceiptHash: Uint8Array
     parentNumber: number
-    primaryParentHash: Uint8Array
+    consensusParentHash: Uint8Array
     preStateRoot: Uint8Array
     postStateRoot: Uint8Array
     proof: StorageProof
     executionPhase: ExecutionPhase
 }
 
+export interface InvalidTransactionProof {
+    domainId: number
+    blockNumber: number
+    domainBlockHash: Uint8Array
+    invalidExtrinsic: Uint8Array
+    storageProof: StorageProof
+}
+
+export interface BundleEquivocationProof {
+    domainId: number
+    offender: Uint8Array
+    slot: bigint
+    firstHeader: SealedBundleHeader
+    secondHeader: SealedBundleHeader
+}
+
 export interface ImproperTransactionSortitionProof {
     domainId: number
-}
-
-export interface BundleHeader {
-    primaryNumber: number
-    primaryHash: Uint8Array
-    slotNumber: bigint
-    extrinsicsRoot: Uint8Array
-}
-
-export type BalanceStatus = BalanceStatus_Free | BalanceStatus_Reserved
-
-export interface BalanceStatus_Free {
-    __kind: 'Free'
-}
-
-export interface BalanceStatus_Reserved {
-    __kind: 'Reserved'
 }
 
 export interface Digest {
@@ -1818,40 +824,23 @@ export interface ArchivedBlockProgress_Partial {
 export interface Solution {
     publicKey: Uint8Array
     rewardAddress: Uint8Array
-    sectorIndex: bigint
-    totalPieces: bigint
-    pieceOffset: bigint
-    recordCommitmentHash: Scalar
-    pieceWitness: Witness
-    chunkOffset: number
+    sectorIndex: number
+    historySize: bigint
+    pieceOffset: number
+    recordCommitment: Commitment
+    recordWitness: Witness
     chunk: Scalar
-    chunkSignature: ChunkSignature
+    chunkWitness: Witness
+    auditChunkOffset: number
+    proofOfSpace: Uint8Array
 }
 
-export interface ExecutionReceipt {
-    primaryNumber: number
-    primaryHash: Uint8Array
-    domainHash: Uint8Array
-    trace: Uint8Array[]
-    traceRoot: Uint8Array
-}
-
-export interface Type_158 {
-    leafIndex: number
-    proof: Uint8Array
-    numberOfLeaves: number
-}
-
-export interface ProofOfElection {
-    domainId: number
-    vrfOutput: Uint8Array
-    vrfProof: Uint8Array
-    executorPublicKey: Uint8Array
-    globalChallenge: Uint8Array
-    stateRoot: Uint8Array
-    storageProof: StorageProof
-    blockNumber: number
-    blockHash: Uint8Array
+export interface BundleHeader {
+    proofOfElection: ProofOfElection
+    receipt: ExecutionReceipt
+    bundleSize: number
+    estimatedBundleWeight: Weight
+    bundleExtrinsicsRoot: Uint8Array
 }
 
 export interface StorageProof {
@@ -1901,15 +890,67 @@ export interface DigestItem_RuntimeEnvironmentUpdated {
     __kind: 'RuntimeEnvironmentUpdated'
 }
 
-export interface Scalar {
-    inner: Uint8Array
-}
-
 export interface Witness {
     inner: Uint8Array
 }
 
-export interface ChunkSignature {
+export interface Scalar {
+    inner: Uint8Array
+}
+
+export interface ProofOfElection {
+    domainId: number
+    slotNumber: bigint
+    globalRandomness: Uint8Array
+    vrfSignature: VrfSignature
+    operatorId: bigint
+}
+
+export interface ExecutionReceipt {
+    domainBlockNumber: number
+    domainBlockHash: Uint8Array
+    parentDomainBlockReceiptHash: Uint8Array
+    consensusBlockNumber: number
+    consensusBlockHash: Uint8Array
+    invalidBundles: InvalidBundle[]
+    blockExtrinsicsRoots: Uint8Array[]
+    finalStateRoot: Uint8Array
+    executionTrace: Uint8Array[]
+    executionTraceRoot: Uint8Array
+    totalRewards: bigint
+}
+
+export interface VrfSignature {
     output: Uint8Array
     proof: Uint8Array
+}
+
+export interface InvalidBundle {
+    bundleIndex: number
+    invalidBundleType: InvalidBundleType
+}
+
+export type InvalidBundleType = InvalidBundleType_UndecodableTx | InvalidBundleType_OutOfRangeTx | InvalidBundleType_IllegalTx | InvalidBundleType_InvalidReceipt
+
+export interface InvalidBundleType_UndecodableTx {
+    __kind: 'UndecodableTx'
+}
+
+export interface InvalidBundleType_OutOfRangeTx {
+    __kind: 'OutOfRangeTx'
+}
+
+export interface InvalidBundleType_IllegalTx {
+    __kind: 'IllegalTx'
+}
+
+export interface InvalidBundleType_InvalidReceipt {
+    __kind: 'InvalidReceipt'
+    value: InvalidReceipt
+}
+
+export type InvalidReceipt = InvalidReceipt_InvalidBundles
+
+export interface InvalidReceipt_InvalidBundles {
+    __kind: 'InvalidBundles'
 }

--- a/squid-blockexplorer/typegen.json
+++ b/squid-blockexplorer/typegen.json
@@ -1,6 +1,6 @@
 {
   "outDir": "src/types",
-  "specVersions": "https://archive.gemini-3d.subspace.network/api",
+  "specVersions": "https://archive.gemini-3f.subspace.network/graphql",
   "constants": true,
   "events": true,
   "calls": true,


### PR DESCRIPTION
Updated the Space pledge calc to just make the bigInt conversion on the final return. Same on history size. Check file `utils.ts`

Updated types for gemini-3f - these rest of the files are auto-generated.

Test environment test on the update looks like so:
![image](https://github.com/subspace/astral/assets/5139220/d233cd6e-4074-4fb3-8bc1-f3a779bfb1ed)

