### PR TITLE
feat(spaceCalc): update space pledge calc for gemini 3g

### DIFF
--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -108,7 +108,7 @@ export function solutionRangeToSectors(solutionRange: bigint): bigint {
   const RECORD_NUM_CHUNKS = 32768n;
   const RECORD_NUM_S_BUCKETS = 65536n;
 
-const sectors = MAX_U64
+  const sectors = MAX_U64
       / SLOT_PROBABILITY[1] * SLOT_PROBABILITY[0]
       / (MAX_PIECES_IN_SECTOR * RECORD_NUM_CHUNKS / RECORD_NUM_S_BUCKETS);
 

--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -98,22 +98,18 @@ const MAX_PIECES_IN_SECTOR = 1000n;
 
 /**
  * Calculates the number of sectors pledged by a solution range, based on monorepo calculation
- * in function solution_range_to_sectors: https://github.com/subspace/subspace/blob/main/crates/subspace-runtime/src/lib.rs#L240-252
+ * in function solution_range_to_sectors: https://github.com/subspace/subspace/blob/main/crates/subspace-runtime/src/lib.rs#L227-L236
  * @param {bigint} solutionRange - range of the solution
  * @return {bigint} - sectors pledged number
  */
 export function solutionRangeToSectors(solutionRange: bigint): bigint {
-  const SIZE_OF_SOLUTION_RANGE = 8n;
-  const SCALAR_FULL_BYTES = 32n;
   const MAX_U64 = 2n ** 64n - 1n;
   const SLOT_PROBABILITY = [1n, 6n];
   const RECORD_NUM_CHUNKS = 32768n;
   const RECORD_NUM_S_BUCKETS = 65536n;
 
-  const auditChunksPerChunk = SCALAR_FULL_BYTES / SIZE_OF_SOLUTION_RANGE;
-  const sectors = MAX_U64
+const sectors = MAX_U64
       / SLOT_PROBABILITY[1] * SLOT_PROBABILITY[0]
-      / auditChunksPerChunk
       / (MAX_PIECES_IN_SECTOR * RECORD_NUM_CHUNKS / RECORD_NUM_S_BUCKETS);
 
   // Take solution range into account
@@ -122,7 +118,7 @@ export function solutionRangeToSectors(solutionRange: bigint): bigint {
 
 /**
  * Calculates the space pledged by a solution range, based on monorepo calculation
- * in function TotalSpacePledged: https://github.com/subspace/subspace/blob/f782f7297a6d61d8f22a3b10d201396fe30708fd/crates/subspace-runtime/src/lib.rs#L396-L399
+ * in function TotalSpacePledged: https://github.com/subspace/subspace/blob/main/crates/subspace-runtime/src/lib.rs#L442-L447
  * @param {bigint} solutionRange - range of the solution
  * @return {bigint} - space pledged in bytes
  */


### PR DESCRIPTION
Update the function `solutionRangeToSectors` so it's the same as the new implementation on the monorepo

As stated in this PR: https://github.com/subspace/subspace/pull/2164

close #355 