### PR TITLE
Change rewardEventsConnection orderBy to Descending

### DIFF
--- a/client/src/Account/query.ts
+++ b/client/src/Account/query.ts
@@ -172,7 +172,7 @@ export const QUERY_LAST_WEEK_REWARDS = gql`
 export const QUERY_REWARDS_LIST = gql`
   query RewardsList($accountId: String!, $first: Int!, $after: String) {
     rewardEventsConnection(
-      orderBy: id_ASC
+      orderBy: id_DESC
       first: $first
       after: $after
       where: { account: { id_eq: $accountId } }


### PR DESCRIPTION
This adjustment ensures that the query results are now ordered from the most recent (highest id) to the oldest (lowest id), which aligns better with the intended data presentation logic. The change impacts the way reward events are listed, making the most recent events appear first.