### PR TITLE
Add VS Code settings

### DIFF
--- a/.vscode/astral.code-workspace
+++ b/.vscode/astral.code-workspace
@@ -1,0 +1,35 @@
+{
+  "folders": [
+    {
+      "name": "root",
+      "path": ".."
+    },
+    {
+      "name": "client",
+      "path": "../client"
+    },
+    {
+      "name": "health-check",
+      "path": "../health-check"
+    },
+    {
+      "name": "squid-blockexplorer",
+      "path": "../squid-blockexplorer"
+    }
+  ],
+  "settings": {
+    "editor.codeActionsOnSave": {
+      "source.sortImports": true,
+      "source.fixAll.eslint": true,
+      "source.fixAll.tslint": true
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "javascript.updateImportsOnFileMove.enabled": "always",
+    "eslint.workingDirectories": [{ "mode": "auto" }],
+    "javascript.format.enable": false,
+    "editor.tabSize": 2,
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": true,
+    "editor.formatOnSave": true,
+    "cSpell.words": ["subspace", "gemini", "subscan", "extrinsics"]
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "eamodio.gitlens",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.sortImports": true,
+    "source.fixAll.eslint": true,
+    "source.fixAll.tslint": true
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "eslint.workingDirectories": [{ "mode": "auto" }],
+  "javascript.format.enable": false,
+  "editor.tabSize": 2,
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": true,
+  "editor.formatOnSave": true,
+  "cSpell.words": ["subspace", "gemini", "subscan", "extrinsics"]
+}


### PR DESCRIPTION
## Add VS Code settings

Small PR to add VS Code settings to the repo, auto-prettier on save and such

- .vscode/settings.json is used when ever you simply open the project
- .vscode/astral.code-workspace.json allow you to work on this mono-repo as a Workspace and therefore list the different workspace and include the same vscode settings that will apply to all workspaces
- .vscode/extensions.json is a list of suggested vscode extension for this project