### PR TITLE
feat(client): enable users to download full leaderboards dataset

### DIFF
--- a/client/src/Leaderboard/components/NominatorRewardsList.tsx
+++ b/client/src/Leaderboard/components/NominatorRewardsList.tsx
@@ -98,6 +98,9 @@ const NominatorRewardsList = () => {
         <NominatorRewardsListTable accounts={accountRewardsConnection} page={currentPage} />
         <div className='w-full flex justify-between gap-2'>
           <ExportButton data={accountRewardsConnection} filename='account-list' />
+          <div className='hidden md:flex w-full'>
+            <LazyExportButton query={fullDataDownloader} filename='account-list' />
+          </div>
           <Pagination
             nextPage={handleNextPage}
             previousPage={handlePreviousPage}
@@ -109,7 +112,7 @@ const NominatorRewardsList = () => {
             onChange={onChange}
           />
         </div>
-        <div className='w-full flex mt-2 justify-center md:justify-end'>
+        <div className='w-full flex md:hidden mt-2 justify-center md:justify-end'>
           <LazyExportButton query={fullDataDownloader} filename='account-list' />
         </div>
       </div>

--- a/client/src/Leaderboard/components/NominatorRewardsList.tsx
+++ b/client/src/Leaderboard/components/NominatorRewardsList.tsx
@@ -1,40 +1,69 @@
-import { useState } from 'react'
+import { useApolloClient, useQuery } from '@apollo/client'
+import { useCallback, useState } from 'react'
 import { useErrorHandler } from 'react-error-boundary'
-import { useQuery } from '@apollo/client'
 
 // common
 import { Pagination, Spinner } from 'common/components'
 import ExportButton from 'common/components/ExportButton'
 import NotAllowed from 'common/components/NotAllowed'
-import { PAGE_SIZE } from 'common/constants'
+import { MAX_DOWNLOADER_BATCH_SIZE, PAGE_SIZE } from 'common/constants'
 import useDomains from 'common/hooks/useDomains'
 
 // leaderboard
 import { QUERY_NOMINATORS_REWARDS_LIST } from 'Leaderboard/querys'
+import LazyExportButton from '../../common/components/LazyExportButton'
 import NominatorRewardsListTable from './NominatorRewardsListTable'
 
 const NominatorRewardsList = () => {
-  const [currentPage, setCurrentPage] = useState(0)
-  const [lastCursor, setLastCursor] = useState<string | undefined>(undefined)
+  const [currentPage, setCurrentPage] = useState( 0 )
+  const [lastCursor, setLastCursor] = useState<string | undefined>( undefined )
   const { selectedChain } = useDomains()
+  const apolloClient = useApolloClient()
 
-  const { data, error, loading } = useQuery(QUERY_NOMINATORS_REWARDS_LIST, {
+  const { data, error, loading } = useQuery( QUERY_NOMINATORS_REWARDS_LIST, {
     variables: { first: PAGE_SIZE, after: lastCursor },
     pollInterval: 6000,
-  })
+  } )
 
-  useErrorHandler(error)
+  useErrorHandler( error )
 
-  if (loading) {
+  const extractAccountRewardsConnection = ( data ) => data.accountRewardsConnection.edges.map(
+    ( accountRewards ) => accountRewards.node,
+  )
+
+  const fullDataDownloader = useCallback( async () => {
+    const entries: unknown[] = []
+
+    let hasNextPage = true
+    while ( hasNextPage ) {
+      const { data } = await apolloClient.query( {
+        query: QUERY_NOMINATORS_REWARDS_LIST,
+        variables: { first: MAX_DOWNLOADER_BATCH_SIZE, after: entries.length ? entries.length.toString() : undefined },
+      } )
+
+      const accounts = extractAccountRewardsConnection( data )
+
+      entries.push( ...accounts )
+
+      hasNextPage = entries.length < data.accountRewardsConnection.totalCount
+    }
+
+
+
+    return entries
+  }, [apolloClient] )
+
+
+  if ( loading ) {
     return <Spinner />
   }
 
-  if (selectedChain.title !== 'Gemini 3g' || selectedChain.isDomain) {
+  if ( selectedChain.title !== 'Gemini 3g' || selectedChain.isDomain ) {
     return <NotAllowed />
   }
 
   const accountRewardsConnection = data.accountRewardsConnection.edges.map(
-    (accountRewards) => accountRewards.node,
+    ( accountRewards ) => accountRewards.node,
   )
   const totalCount = data.accountRewardsConnection.totalCount
   // const totalLabel = numberWithCommas(Number(totalCount))
@@ -42,25 +71,25 @@ const NominatorRewardsList = () => {
   const pageInfo = data.accountRewardsConnection.pageInfo
 
   const handleNextPage = () => {
-    setCurrentPage((prev) => prev + 1)
-    setLastCursor(pageInfo.endCursor)
+    setCurrentPage( ( prev ) => prev + 1 )
+    setLastCursor( pageInfo.endCursor )
   }
 
   const handlePreviousPage = () => {
-    setCurrentPage((prev) => prev - 1)
-    setLastCursor(pageInfo.endCursor)
+    setCurrentPage( ( prev ) => prev - 1 )
+    setLastCursor( pageInfo.endCursor )
   }
 
-  const onChange = (page: number) => {
-    setCurrentPage(Number(page))
+  const onChange = ( page: number ) => {
+    setCurrentPage( Number( page ) )
 
-    const newCount = page > 0 ? PAGE_SIZE * Number(page + 1) : PAGE_SIZE
+    const newCount = page > 0 ? PAGE_SIZE * Number( page + 1 ) : PAGE_SIZE
     const endCursor = newCount - PAGE_SIZE
 
-    if (endCursor === 0 || endCursor < 0) {
-      return setLastCursor(undefined)
+    if ( endCursor === 0 || endCursor < 0 ) {
+      return setLastCursor( undefined )
     }
-    setLastCursor(endCursor.toString())
+    setLastCursor( endCursor.toString() )
   }
 
   return (
@@ -79,6 +108,9 @@ const NominatorRewardsList = () => {
             hasPreviousPage={pageInfo.hasPreviousPage}
             onChange={onChange}
           />
+        </div>
+        <div className='w-full flex mt-2 justify-center md:justify-end'>
+          <LazyExportButton query={fullDataDownloader} filename='account-list' />
         </div>
       </div>
     </div>

--- a/client/src/Leaderboard/components/OperatorRewardsList.tsx
+++ b/client/src/Leaderboard/components/OperatorRewardsList.tsx
@@ -95,6 +95,9 @@ const OperatorRewardsList = () => {
         <OperatorRewardsListTable operators={operatorRewardsConnection} page={currentPage} />
         <div className='w-full flex justify-between gap-2'>
           <ExportButton data={operatorRewardsConnection} filename='account-list' />
+          <div className='hidden md:flex w-full'>
+            <LazyExportButton query={fullDataDownloader} filename='account-list' />
+          </div>
           <Pagination
             nextPage={handleNextPage}
             previousPage={handlePreviousPage}
@@ -106,7 +109,7 @@ const OperatorRewardsList = () => {
             onChange={onChange}
           />
         </div>
-        <div className='w-full flex mt-2 justify-center md:justify-end'>
+        <div className='w-full flex md:hidden mt-2 justify-center md:justify-end'>
           <LazyExportButton query={fullDataDownloader} filename='account-list' />
         </div>
       </div>

--- a/client/src/Leaderboard/components/VoteBlockRewardList.tsx
+++ b/client/src/Leaderboard/components/VoteBlockRewardList.tsx
@@ -97,6 +97,9 @@ const VoteBlockRewardList = () => {
         <VoteBlockRewardTable accounts={accountRewardsConnection} page={currentPage} />
         <div className='w-full flex justify-between gap-2'>
           <ExportButton data={accountRewardsConnection} filename='account-list' />
+          <div className='hidden md:flex w-full'>
+            <LazyExportButton query={fullDataDownloader} filename='account-list' />
+          </div>
           <Pagination
             nextPage={handleNextPage}
             previousPage={handlePreviousPage}
@@ -108,7 +111,7 @@ const VoteBlockRewardList = () => {
             onChange={onChange}
           />
         </div>
-        <div className='w-full flex mt-2 justify-center md:justify-end'>
+        <div className='w-full flex md:hidden mt-2 justify-center md:justify-end'>
           <LazyExportButton query={fullDataDownloader} filename='account-list' />
         </div>
       </div>

--- a/client/src/common/components/LazyExportButton.tsx
+++ b/client/src/common/components/LazyExportButton.tsx
@@ -1,0 +1,48 @@
+import { FC, useState } from 'react'
+// common
+import { exportToExcel } from 'common/helpers/exportToExcel'
+
+type Props = {
+  query: () => Promise<unknown[]>
+  filename: string
+}
+
+type ButtonStates = 'idle' | 'loading' | 'error'
+
+const textByState: Record<ButtonStates, string> = {
+  idle: 'Download Full Data',
+  loading: 'Loading...',
+  error: 'Error',
+}
+
+const LazyExportButton: FC<Props> = ( { query, filename } ) => {
+  const [state, setState] = useState<ButtonStates>( 'idle' )
+
+  const handleClick = () => {
+    setState( 'loading' )
+    query().then( ( data ) => {
+      exportToExcel( data, `${filename}.xlsx` );
+      setState( 'idle' )
+    } ).catch( e => {
+      console.error( e )
+      setState( 'error' )
+      setTimeout( () => setState( 'idle' ), 3000 )
+    } )
+  }
+
+  const text = textByState[state]
+
+  return (
+    <button
+      className='w-full max-w-fit flex gap-2 text-sm md:text-base items-center md:space-x-4 rounded-full border-2 border-[#241235] text-[#241235] px-2 md:px-4 py-2 md:py-[10px] font-medium dark:bg-[#1E254E]'
+      onClick={handleClick}
+    >
+      <span className='hidden md:block'>{text}</span>
+      <span className='flex md:hidden items-center justify-around gap-1 p-1'>
+        {text}
+      </span>
+    </button>
+  )
+}
+
+export default LazyExportButton

--- a/client/src/common/components/LazyExportButton.tsx
+++ b/client/src/common/components/LazyExportButton.tsx
@@ -34,7 +34,7 @@ const LazyExportButton: FC<Props> = ( { query, filename } ) => {
 
   return (
     <button
-      className='w-full max-w-fit flex gap-2 text-sm md:text-base items-center md:space-x-4 rounded-full border-2 border-[#241235] text-[#241235] px-2 md:px-4 py-2 md:py-[10px] font-medium dark:bg-[#1E254E]'
+      className='w-full max-w-fit flex gap-2 text-sm md:text-base items-center md:space-x-4 rounded-full border-2 border-[#241235] text-[#241235] px-2 md:px-4 py-2 md:py-[10px] font-medium dark:bg-[#1E254E] dark:text-white'
       onClick={handleClick}
     >
       <span className='hidden md:block'>{text}</span>

--- a/client/src/common/components/LazyExportButton.tsx
+++ b/client/src/common/components/LazyExportButton.tsx
@@ -10,7 +10,7 @@ type Props = {
 type ButtonStates = 'idle' | 'loading' | 'error'
 
 const textByState: Record<ButtonStates, string> = {
-  idle: 'Download Full Data',
+  idle: 'Download full leaderboard',
   loading: 'Loading...',
   error: 'Error',
 }

--- a/client/src/common/constants/index.ts
+++ b/client/src/common/constants/index.ts
@@ -1,5 +1,7 @@
 export const PAGE_SIZE = 10
 
+export const MAX_DOWNLOADER_BATCH_SIZE = 100
+
 export type SearchType = {
   id: number
   name: string

--- a/client/src/gql/index.ts
+++ b/client/src/gql/index.ts
@@ -1,2 +1,2 @@
-export * from "./fragment-masking";
-export * from "./gql";
+export * from './fragment-masking';
+export * from './gql';


### PR DESCRIPTION
As requested in #407 , these changes enables the user to download the whole dataset for each leaderboard. 

Applied changes:

* Created the component `LazyExportButton` which is really similar to former `ExportButton` but instead of receiving a `unknown[]` type is receiving a `() => Promise<unknown[]>` this allows to only download the whole dataset when the user request it (that's why is called lazy).

* Added new constant `MAX_DOWNLOADER_BATCH_SIZE=200` for knowing how much items could be retrieved by batch when downloading the whole dataset to avoid reaching the maximum response size from the API.  

Minor changes: 

* Ran `lint:fix` command for fixing some linter errors.

Checks I've made:

* Check that in both mobile and standard displays is shown correctly
* Download is correctly made for three leaderboards.
* Error management in download is correctly handled.

Resulting user interface:

Standard:

<img width="1259" alt="image" src="https://github.com/subspace/astral/assets/49268919/dbaa9e7d-4e8e-4039-9c95-ed3353c4102b">

Mobile:
<img width="318" alt="image" src="https://github.com/subspace/astral/assets/49268919/433140fc-a604-47b8-94bd-953b70346412">

