### PR TITLE
Add * catchAll route to show 404 page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,8 @@
-import { Routes, Route, Navigate, useLocation, HashRouter } from 'react-router-dom'
+import { HashRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 
 // common
-import { INTERNAL_ROUTES } from 'common/routes'
 import useDomains from 'common/hooks/useDomains'
+import { INTERNAL_ROUTES } from 'common/routes'
 
 // block
 import { Block, BlockList } from 'Block/components'
@@ -19,7 +19,7 @@ import SearchResult from 'layout/components/SearchResult'
 import Home from 'Home'
 
 // account
-import { AccountList, Account, AccountRewardList } from 'Account/components'
+import { Account, AccountList, AccountRewardList } from 'Account/components'
 
 // event
 import { Event, EventList } from 'Event/components'
@@ -32,11 +32,11 @@ import Operator from 'Operator/components/Operator'
 import OperatorsList from 'Operator/components/OperatorsList'
 
 // leaderboard
-import LeaderboardLayout from 'layout/components/LeaderboardLayout'
-import VoteBlockRewardList from 'Leaderboard/components/VoteBlockRewardList'
 import NominatorRewardsList from 'Leaderboard/components/NominatorRewardsList'
 import OperatorRewardsList from 'Leaderboard/components/OperatorRewardsList'
+import VoteBlockRewardList from 'Leaderboard/components/VoteBlockRewardList'
 import DomainLayout from 'layout/components/DomainLayout'
+import LeaderboardLayout from 'layout/components/LeaderboardLayout'
 import { Fragment, ReactNode, useEffect } from 'react'
 
 const createDomainRoutes = () => {
@@ -141,6 +141,7 @@ const App = () => {
           ))}
           <Route element={<NotFound />} path={INTERNAL_ROUTES.notFound} />
           <Route element={<NotResultsFound />} path={INTERNAL_ROUTES.search.empty} />
+          <Route element={<NotFound />} path={INTERNAL_ROUTES.catchAll} />
         </Routes>
       </UpdateSelectedChainByPath>
     </HashRouter>

--- a/client/src/common/routes/index.ts
+++ b/client/src/common/routes/index.ts
@@ -86,4 +86,5 @@ export const INTERNAL_ROUTES = {
     nominators: 'nominators',
   },
   notFound: '/404',
+  catchAll: '*',
 }


### PR DESCRIPTION
## Add * catchAll route to show 404 page

Currently if you make a typo in the url or for example try to load the page for a old domain, you simply get a white page.

You can test the current behaviour with this [example](https://explorer.subspace.network/#/gemini-3f)

With this, we add a `*` route that will catch any path not already resolved and display the 404 page.