### PR TITLE
Add nominators list page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,7 @@ import { Log, LogList } from 'Log/components'
 
 // operator
 import NominationManagement from 'Operator/components/NominationManagement'
+import NominatorsList from 'Operator/components/NominatorsList'
 import OperatorManagement from 'Operator/components/OperatorManagement'
 import OperatorStake from 'Operator/components/OperatorStake'
 import OperatorsList from 'Operator/components/OperatorsList'
@@ -148,6 +149,7 @@ const App = () => {
                 <Route path={INTERNAL_ROUTES.operators.list} element={<OperatorsList />} />
                 <Route path={INTERNAL_ROUTES.operators.stake} element={<OperatorStake />} />
                 <Route path={INTERNAL_ROUTES.operators.manage} element={<OperatorManagement />} />
+                <Route path={INTERNAL_ROUTES.operators.nominators} element={<NominatorsList />} />
                 <Route
                   path={INTERNAL_ROUTES.operators.nomination}
                   element={<NominationManagement />}

--- a/client/src/Operator/components/NominatorsList.tsx
+++ b/client/src/Operator/components/NominatorsList.tsx
@@ -1,0 +1,321 @@
+import { useApolloClient, useQuery } from '@apollo/client'
+import { SortingState } from '@tanstack/react-table'
+import { Nominator, NominatorsConnection } from 'gql/graphql'
+import { FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { useErrorHandler } from 'react-error-boundary'
+import { Link, useParams } from 'react-router-dom'
+
+// common
+import { Spinner } from 'common/components'
+import NewTable from 'common/components/NewTable'
+import { PAGE_SIZE } from 'common/constants'
+import {
+  bigNumberToNumber,
+  downloadFullData,
+  limitNumberDecimals,
+  numberWithCommas,
+  shortString,
+} from 'common/helpers'
+import useDomains from 'common/hooks/useDomains'
+import useWallet from 'common/hooks/useWallet'
+import { INTERNAL_ROUTES } from 'common/routes'
+
+// operator
+import { QUERY_NOMINATOR_CONNECTION_LIST } from 'Operator/query'
+import { ActionsDropdown } from './ActionsDropdown'
+import { ActionsModal, OperatorAction, OperatorActionType } from './ActionsModal'
+import NominatorListCard from './NominatorListCard'
+
+const NominatorsList: FC = () => {
+  const [searchNominator, setSearch] = useState<string>('')
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'id', desc: false }])
+  const [pagination, setPagination] = useState({
+    pageSize: PAGE_SIZE,
+    pageIndex: 0,
+  })
+  const { subspaceAccount } = useWallet()
+  const { operatorId } = useParams<{ operatorId?: string }>()
+
+  const [action, setAction] = useState<OperatorAction>({
+    type: OperatorActionType.None,
+    operatorId: operatorId ? parseInt(operatorId) : null,
+    maxAmount: null,
+  })
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  const handleAction = useCallback((value: OperatorAction) => {
+    setAction(value)
+    if (value.type !== OperatorActionType.None) setIsOpen(true)
+  }, [])
+  const handleActionClose = useCallback(() => {
+    setIsOpen(false)
+    setAction({ type: OperatorActionType.None, operatorId: null, maxAmount: null })
+  }, [])
+
+  const { selectedChain, selectedDomain } = useDomains()
+  const apolloClient = useApolloClient()
+
+  const columns = useMemo(() => {
+    const cols = [
+      {
+        accessorKey: 'nominator',
+        header: 'Nominator',
+        enableSorting: true,
+        cell: ({ row }) => (
+          <Link
+            data-testid={`operator-link-${row.original.id}-${row.original.signingKey}-${row.index}}`}
+            className='hover:text-[#DE67E4]'
+            to={INTERNAL_ROUTES.accounts.id.page(
+              selectedChain.urls.page,
+              'consensus',
+              row.original.account.id,
+            )}
+          >
+            <div>{shortString(row.original.account.id)}</div>
+          </Link>
+        ),
+      },
+      {
+        accessorKey: 'currentDomainId',
+        header: 'Domain',
+        enableSorting: true,
+        cell: ({ row }) => <div>{row.original.currentDomainId === 0 ? 'Subspace' : 'Nova'}</div>,
+      },
+      {
+        accessorKey: 'operatorId',
+        header: 'OperatorId',
+        enableSorting: true,
+        cell: ({ row }) => (
+          <div className='flex row items-center gap-3'>
+            <Link
+              data-testid={`nominator-link-${row.original.id}-${row.original.signingKey}-${row.index}}`}
+              className='hover:text-[#DE67E4]'
+              to={INTERNAL_ROUTES.operators.id.page(
+                selectedChain.urls.page,
+                selectedDomain,
+                row.original.operator.id,
+              )}
+            >
+              <div>{row.original.operator.id}</div>
+            </Link>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'stakes',
+        header: 'Stakes',
+        enableSorting: true,
+        cell: ({ row }) => (
+          <div>
+            {numberWithCommas(
+              limitNumberDecimals(
+                Number(
+                  Number(
+                    (BigInt(row.original.operator.currentTotalStake) /
+                      BigInt(row.original.operator.totalShares)) *
+                      BigInt(row.original.shares),
+                  ) /
+                    10 ** 18,
+                ),
+              ),
+            )}{' '}
+            tSSC
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'shares',
+        header: 'Shares',
+        enableSorting: true,
+        cell: ({ row }) => (
+          <div>
+            {numberWithCommas(
+              limitNumberDecimals(
+                Number(
+                  Number(
+                    (BigInt(row.original.shares) * BigInt(1000000000)) /
+                      BigInt(row.original.operator.totalShares),
+                  ) / 1000000000,
+                ),
+              ),
+            )}{' '}
+            %
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'minimumNominatorStake',
+        header: 'Min. Stake',
+        enableSorting: true,
+        cell: ({ row }) => (
+          <div>{`${bigNumberToNumber(row.original.operator.minimumNominatorStake)} tSSC`}</div>
+        ),
+      },
+      {
+        accessorKey: 'nominationTax',
+        header: 'Nominator Tax',
+        enableSorting: true,
+        cell: ({ row }) => <div>{`${row.original.operator.nominationTax}%`}</div>,
+      },
+      {
+        accessorKey: 'currentTotalStake',
+        header: 'Total Stake',
+        enableSorting: true,
+        cell: ({ row }) => (
+          <div>{`${bigNumberToNumber(row.original.operator.currentTotalStake)} tSSC`}</div>
+        ),
+      },
+      {
+        accessorKey: 'status',
+        header: 'Status',
+        enableSorting: true,
+        cell: ({ row }) => <div>{row.original.operator.status}</div>,
+      },
+    ]
+    if (subspaceAccount)
+      cols.push({
+        accessorKey: 'actions',
+        header: 'Actions',
+        enableSorting: false,
+        cell: ({ row }) => {
+          if (row.original.account.id !== subspaceAccount) return <> </>
+          return (
+            <ActionsDropdown
+              action={action}
+              handleAction={handleAction}
+              row={row}
+              excludeActions={[OperatorActionType.Deregister]}
+              nominatorMaxStake={(
+                (BigInt(row.original.operator.currentTotalStake) * BigInt(row.original.shares)) /
+                BigInt(row.original.operator.totalShares)
+              ).toString()}
+            />
+          )
+        },
+      })
+    return cols
+  }, [subspaceAccount, selectedChain.urls.page, selectedDomain, action, handleAction])
+
+  const variables = useMemo(
+    () => ({
+      first: pagination.pageSize,
+      after:
+        pagination.pageIndex > 0
+          ? (pagination.pageIndex * pagination.pageSize).toString()
+          : undefined,
+      orderBy: sorting.map((s) => `${s.id}_${s.desc ? 'DESC' : 'ASC'}`).join(',') || 'id_ASC',
+      // eslint-disable-next-line camelcase
+      where: searchNominator ? { account: { id_eq: searchNominator } } : {},
+    }),
+    [sorting, pagination, searchNominator],
+  )
+
+  const { data, error, loading } = useQuery(QUERY_NOMINATOR_CONNECTION_LIST, {
+    variables: variables,
+    pollInterval: 6000,
+  })
+
+  useErrorHandler(error)
+
+  const fullDataDownloader = useCallback(
+    () => downloadFullData(apolloClient, QUERY_NOMINATOR_CONNECTION_LIST),
+    [apolloClient],
+  )
+
+  const handleSearch = useCallback((value: string | number) => {
+    setSearch(value.toString())
+    setPagination({ ...pagination, pageIndex: 0 })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const nominators: NominatorsConnection = useMemo(
+    () => (data && data.nominatorsConnection ? data.nominatorsConnection : []),
+    [data],
+  )
+  const nominatorsConnection: Nominator[] = useMemo(
+    () =>
+      nominators && nominators.edges ? nominators.edges.map((nominator) => nominator.node) : [],
+    [nominators],
+  )
+  const totalCount = useMemo(() => (nominators ? nominators.totalCount : 0), [nominators])
+  const totalLabel = useMemo(() => numberWithCommas(Number(totalCount)), [totalCount])
+
+  const pageCount = useMemo(
+    () => Math.floor(totalCount / pagination.pageSize),
+    [totalCount, pagination],
+  )
+
+  useEffect(() => {
+    if (operatorId) handleSearch(operatorId)
+  }, [operatorId, handleSearch])
+
+  if (loading) {
+    return <Spinner />
+  }
+
+  return (
+    <div className='w-full flex flex-col align-middle'>
+      <div className='flex flex-col gap-2'>
+        <div className='w-full flex justify-between mt-5'>
+          <div className='text-[#282929] text-base font-medium dark:text-white'>{`Nominators (${totalLabel})`}</div>
+        </div>
+      </div>
+
+      <div className='w-full flex flex-col mt-5 sm:mt-0'>
+        <div className='rounded my-6'>
+          <NewTable
+            data={nominatorsConnection}
+            columns={columns}
+            showNavigation={true}
+            sorting={sorting}
+            onSortingChange={setSorting}
+            pagination={pagination}
+            pageCount={pageCount}
+            onPaginationChange={setPagination}
+            fullDataDownloader={fullDataDownloader}
+            mobileComponent={
+              <MobileComponent
+                nominators={nominatorsConnection}
+                action={action}
+                handleAction={handleAction}
+                subspaceAccount={subspaceAccount}
+              />
+            }
+          />
+        </div>
+      </div>
+      <ActionsModal isOpen={isOpen} action={action} onClose={handleActionClose} />
+    </div>
+  )
+}
+
+export default NominatorsList
+
+type MobileComponentProps = {
+  nominators: Nominator[]
+  action: OperatorAction
+  handleAction: (value: OperatorAction) => void
+  subspaceAccount?: string
+}
+
+const MobileComponent: FC<MobileComponentProps> = ({ nominators, action, handleAction }) => (
+  <div className='w-full'>
+    {nominators.map((nominator, index) => (
+      <NominatorListCard
+        key={`operator-list-card-${nominator.id}`}
+        nominator={nominator}
+        action={action}
+        handleAction={handleAction}
+        index={index}
+        excludeActions={[OperatorActionType.Deregister]}
+        nominatorMaxStake={
+          nominator &&
+          (
+            (BigInt(nominator.operator.currentTotalStake) * BigInt(nominator.shares)) /
+            BigInt(nominator.operator.totalShares)
+          ).toString()
+        }
+      />
+    ))}
+  </div>
+)

--- a/client/src/layout/components/OperatorHeader.tsx
+++ b/client/src/layout/components/OperatorHeader.tsx
@@ -78,17 +78,16 @@ const OperatorHeader = () => {
         title: 'Stake My Operator',
         link: `${INTERNAL_ROUTES.operators.stake}`,
       },
-      // TODO: remove comment when these pages are added
-      // {
-      //   title: 'Nominate',
-      //   link: `${INTERNAL_ROUTES.operators.nominate}`,
-      // },
     ]
     if (operatorsConnection && operatorsConnection.length > 0)
       general.push({
         title: 'Manage My Operator',
         link: `${INTERNAL_ROUTES.operators.manage}`,
       })
+    general.push({
+      title: 'Nominators',
+      link: `${INTERNAL_ROUTES.operators.nominators}`,
+    })
     if (nominatorsConnection && nominatorsConnection.length > 0)
       general.push({
         title: 'Manage My Nomination',


### PR DESCRIPTION
## Add nominators list page

- Add a page listing all nominators across all operators

### Linked task

close #457 

### Screenshot

![NominatorsList](https://github.com/subspace/astral/assets/82244926/47e6bbbb-2c30-41b9-9248-a24436799bcc)

### Note

The current % in shares is not valid, since the total shares of the operator object currently return the shares own by the operator, not the aggregate of all nominators 