### PR TITLE
warn user when no balance to stake

### DIFF
--- a/client/src/Operator/components/ActionsModal.tsx
+++ b/client/src/Operator/components/ActionsModal.tsx
@@ -242,10 +242,16 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
                       </div>
                     )}
                   />
-                  {errors.amount && touched.amount ? (
-                    <div className='text-red-500 text-md mt-2 h-8' data-testid='errorMessage'>
-                      {errors.amount}
-                    </div>
+                  {(errors.amount && touched.amount) || maxAmountToAdd === 0 ? (
+                    maxAmountToAdd === 0 ? (
+                      <span className='text-red-500 text-md h-8' data-testid='errorMessage'>
+                        You don&apos;t have enough balance to stake
+                      </span>
+                    ) : (
+                      <div className='text-red-500 text-md mt-2 h-8' data-testid='errorMessage'>
+                        {errors.amount}
+                      </div>
+                    )
                   ) : (
                     <div className='text-md mt-2 h-8' data-testid='placeHolder' />
                   )}
@@ -289,6 +295,7 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
     ErrorPlaceholder,
     actingAccount,
     action.type,
+    maxAmountToAdd,
     fundsFormValidationSchema,
     handleAddFunds,
     handleDeregister,


### PR DESCRIPTION
## Warn user when no balance to stake

If trying to add funds while not having any funds, a warning is shown

### Link issues

- #490 

### Screenshot

![AddFundsNoFunds](https://github.com/subspace/astral/assets/82244926/c29486ba-6b93-445a-97b5-785e1b2dd118)
