### PR TITLE
fix(squid): add get operator before rewards and update operator info

### DIFF
--- a/squid-blockexplorer/src/blocks/processEvents.ts
+++ b/squid-blockexplorer/src/blocks/processEvents.ts
@@ -56,6 +56,12 @@ export function processEventsFactory(
     await addEventModuleName(eventItem.event.name);
 
     switch (eventItem.name) {
+      case "Domains.OperatorRegistered":
+      case "Domains.OperatorDeregistered":
+      case "Domains.OperatorSlashed":
+      case "Domains.OperatorSwitchedDomain":
+        await createOrUpdateOperator(eventItem);
+        return null;
       case "Domains.OperatorRewarded":
         return await processOperatorRewardedEvent(
           eventItem,
@@ -76,6 +82,11 @@ export function processEventsFactory(
       default:
         return null;
     }
+  }
+
+  async function createOrUpdateOperator(eventItem: EventItem){
+    const operatorId = BigInt(eventItem.event.args?.operatorId);
+    await getOrCreateOperator(operatorId);
   }
 
   async function processOperatorRewardedEvent(

--- a/squid-blockexplorer/src/blocks/processEvents.ts
+++ b/squid-blockexplorer/src/blocks/processEvents.ts
@@ -59,7 +59,6 @@ export function processEventsFactory(
       case "Domains.OperatorRegistered":
       case "Domains.OperatorDeregistered":
       case "Domains.OperatorSlashed":
-      case "Domains.OperatorSwitchedDomain":
         await createOrUpdateOperator(eventItem);
         return null;
       case "Domains.OperatorRewarded":

--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -375,6 +375,29 @@ export function getOrCreateOperatorFactory(ctx: Context, api: ApiPromise) {
 
         await ctx.store.insert(operator);
       }
+    } else {
+      const operatorInfo = (
+        await api.query.domains.operators(operatorId)
+      ).toJSON() as any;
+
+      if (operatorInfo) {
+        operator = new Operator({
+          ...operator,
+          status: operatorInfo.status.toString(),
+          signingKey: operatorInfo.signingKey,
+          totalShares: BigInt(operatorInfo.totalShares),
+          currentEpochRewards: operatorInfo.currentEpochRewards,
+          currentTotalStake: BigInt(operatorInfo.currentTotalStake),
+          nominatorAmount: nominatorsLength,
+          nominationTax: operatorInfo.nominationTax,
+          minimumNominatorStake: BigInt(operatorInfo.minimumNominatorStake),
+          nextDomainId: operatorInfo.nextDomainId,
+          currentDomainId: operatorInfo.currentDomainId,
+          updatedAt: BigInt(block.header.height),
+        });
+
+        await ctx.store.save(operator);
+      }
     }
 
     return operator;


### PR DESCRIPTION
close #509 
close #489 

This PR adds updates to index operators before they receive any rewards and updates operators' info based on different events.