### PR TITLE
Improve top header on mobile

### DIFF
--- a/client/src/common/components/IndexingError.tsx
+++ b/client/src/common/components/IndexingError.tsx
@@ -1,4 +1,15 @@
-const IndexingError = () => {
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { FC, useCallback, useState } from 'react'
+
+const IndexingError: FC = () => {
+  const [isWarningVisible, setIsWarningVisible] = useState(true)
+
+  const handleHideWarning = useCallback(() => {
+    setIsWarningVisible(false)
+  }, [])
+
+  if (!isWarningVisible) return <></>
+
   return (
     <div className='w-full flex items-center justify-center bg-orange-600/40 py-2 px-5'>
       <div className='text-gray-600 text-sm font-medium dark:text-white'>
@@ -7,6 +18,12 @@ const IndexingError = () => {
           work to resolve this issue.
         </p>
       </div>
+      <button
+        className='mx-2 w-8 px-1 py-1 bg-white dark:bg-orange-600/40 hover:bg-gray-200 text-gray-800 dark:text-white text-sm font-medium rounded-[20px]'
+        onClick={handleHideWarning}
+      >
+        <XMarkIcon className='w-6 h-6 text-[#282929] dark:text-white' />
+      </button>
     </div>
   )
 }

--- a/client/src/layout/components/DomainHeader.tsx
+++ b/client/src/layout/components/DomainHeader.tsx
@@ -55,8 +55,8 @@ const DomainHeader: FC = () => {
 
   const walletIcon = useMemo(() => <WalletIcon className='w-6 h-6' />, [])
 
-  const domainIcon = useCallback((domain: (typeof DOMAINS)[0]) => {
-    const className = 'w-6 h-6 text-[#282929] dark:text-white'
+  const domainIcon = useCallback((domain: (typeof DOMAINS)[0], isActive: boolean) => {
+    const className = `w-6 h-6 ${isActive ? 'text-white' : 'text-[#282929]'} dark:text-white`
     switch (domain.name) {
       case DOMAINS_NAMES.nova:
         return <GlobeAltIcon className={className} />
@@ -91,7 +91,7 @@ const DomainHeader: FC = () => {
                       : 'bg-white text-[#282929] dark:text-white dark:bg-[#1E254E]'
                   }
                 >
-                  {isDesktop ? item.title : domainIcon(item)}
+                  {isDesktop ? item.title : domainIcon(item, isActive)}
                 </button>
               </div>
             )


### PR DESCRIPTION
## Improve top header on mobile

The current top header on small mobile takes too much space on the x axe to leave enough space for some of the elements (especially "Connect Wallet")

Changing icons on mobile will give us more room

- Use icons for each site domain & wallet
- Change so the wallet dropdown opens on the left

### Note

I'm not especially attached to any of these icon, if you have better one in mind or want to make custom one.

### Screenshots

![Dark-Locked](https://github.com/subspace/astral/assets/82244926/db367267-2711-4d75-829b-9a106a5a777f)
![Dark-Unlocked](https://github.com/subspace/astral/assets/82244926/78e5e006-c3a7-47f0-8f62-67f117029898)
![Dark-DropdownOpen](https://github.com/subspace/astral/assets/82244926/649e972b-edc7-475c-ac7c-7bd308837bc0)
![Light-Locked](https://github.com/subspace/astral/assets/82244926/59364994-7369-4aab-ba6a-ce7d106960f6)
![Light-DropdownOpen](https://github.com/subspace/astral/assets/82244926/ae96914a-678a-41c9-b5f7-d539b1a83a31)


