### PR TITLE
fix(rewards): issue with indexer rewards event

### DIFF
--- a/squid-blockexplorer/src/blocks/processEvents.ts
+++ b/squid-blockexplorer/src/blocks/processEvents.ts
@@ -83,7 +83,7 @@ export function processEventsFactory(
     }
   }
 
-  async function createOrUpdateOperator(eventItem: EventItem){
+  async function createOrUpdateOperator(eventItem: EventItem) {
     const operatorId = BigInt(eventItem.event.args?.operatorId);
     await getOrCreateOperator(operatorId);
   }
@@ -149,7 +149,7 @@ export function processEventsFactory(
       // add tax amount to operator owner
       if (operator.operatorOwner) {
         const rewardTax = operator.nominationTax
-          ? BigInt(operator.nominationTax / 100)
+          ? BigInt(operator.nominationTax)
           : BigInt(0);
 
         const ownerAccount = await getOrCreateAccount(
@@ -157,7 +157,7 @@ export function processEventsFactory(
           operator.operatorOwner
         );
 
-        const nominationTaxAmount = rewardAmount * rewardTax;
+        const nominationTaxAmount = rewardAmount * (rewardTax / BigInt(100));
 
         const rewardEvent = new RewardEvent({
           ...eventItem.event,
@@ -216,10 +216,10 @@ export function processEventsFactory(
     accountRewards: AccountRewards
   ) {
     const rewardTax = operator.nominationTax
-      ? BigInt(operator.nominationTax / 100)
+      ? BigInt(operator.nominationTax)
       : BigInt(0);
     const rewardAmount = BigInt(eventItem.event.args.reward);
-    const reward = rewardAmount - rewardAmount * rewardTax;
+    const reward = rewardAmount - rewardAmount * (rewardTax / BigInt(100));
     const totalShares = operator.totalShares
       ? BigInt(operator.totalShares)
       : BigInt(0);


### PR DESCRIPTION
```
{"level":5,"time":1709894077733,"ns":"sqd:processor","err":{"stack":"RangeError: The number 0.05 cannot be converted to a BigInt because it is not an integer\n    at BigInt (<anonymous>)\n    at processOperatorRewardedEvent (/squid/lib/blocks/processEvents.js:82:23)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async processEventBasedOnName (/squid/lib/blocks/processEvents.js:24:24)\n    at async processEvents (/squid/lib/blocks/processEvents.js:189:33)\n    at async processBlocks (/squid/lib/blocks/processBlocks.js:36:49)\n    at async processChain (/squid/lib/processor.js:36:9)\n    at async TypeormDatabase.runTransaction (/squid/node_modules/@subsquid/typeorm-store/lib/database.js:110:13)\n    at async TypeormDatabase.transact (/squid/node_modules/@subsquid/typeorm-store/lib/database.js:64:24)"}}
```

Fixes issue reported in indexer when gets to block `537220 `