### PR TITLE
Fix z-index with sub-header and wallet sidekick

### DIFF
--- a/.vscode/astral.code-workspace
+++ b/.vscode/astral.code-workspace
@@ -5,6 +5,10 @@
       "path": ".."
     },
     {
+      "name": "explorer",
+      "path": "../explorer"
+    },
+    {
       "name": "client",
       "path": "../client"
     },

--- a/explorer/src/components/layout/LeaderboardHeader.tsx
+++ b/explorer/src/components/layout/LeaderboardHeader.tsx
@@ -38,7 +38,7 @@ export const LeaderboardHeader: FC = () => {
   )
 
   return (
-    <header className="body-font z-10 py-[30px] font-['Montserrat'] text-gray-600">
+    <header className="body-font z-9 py-[30px] font-['Montserrat'] text-gray-600">
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link

--- a/explorer/src/components/layout/OperatorHeader.tsx
+++ b/explorer/src/components/layout/OperatorHeader.tsx
@@ -106,7 +106,7 @@ export const OperatorHeader = () => {
   }, [subspaceAccount])
 
   return (
-    <header className="body-font z-10 py-[30px] font-['Montserrat'] text-gray-600">
+    <header className="body-font z-9 py-[30px] font-['Montserrat'] text-gray-600">
       {isDesktop ? (
         <div className='container mx-auto flex flex-col flex-wrap items-center justify-between py-5 md:flex-row md:px-[25px] 2xl:px-0'>
           <Link


### PR DESCRIPTION
## Fix z-index with sub-header and wallet sidekick

On Leaderboard and Operarot sub header, the z-index was different, causing the issue