### PR TITLE
add netlify CI/CD for production deployment

### DIFF
--- a/.github/workflows/gh-deploy-production.yml
+++ b/.github/workflows/gh-deploy-production.yml
@@ -1,0 +1,24 @@
+name: Deploy to production and preview deploys
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'client/**'
+jobs:
+  deploy:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./client
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+      - name: Deploy to Netlify Action 🚀
+        uses: netlify/actions/cli@master
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_PRODUCTION }}
+        with:
+          args: deploy --dir=client/build
+          secrets: '["NETLIFY_AUTH_TOKEN", "NETLIFY_SITE_ID"]'


### PR DESCRIPTION
## **User description**
The PR adds a github ci/cd workflow to deploy the astral explorer frontend to netlify on changes to main branch for production.

closes https://github.com/subspace/astral/issues/541
___

## **Type**
enhancement


___

## **Description**
- Introduced a GitHub Actions workflow named "Deploy to staging and preview deploys" for automating the deployment of the client application to Netlify.
- The workflow is triggered on updates to the `main` branch, focusing on changes within the `client` directory.
- Deployment steps include checking out the repository and deploying to Netlify using the Netlify CLI action, with `NETLIFY_AUTH_TOKEN_PRODUCTION` and `NETLIFY_SITE_ID_PRODUCTION` provided as secrets.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gh-deploy-production.yml</strong><dd><code>Add Netlify CI/CD Workflow for Production Deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gh-deploy-production.yml
<li>Added a new GitHub Actions workflow for deploying the client <br>application to Netlify.<br> <li> Workflow triggers on push to the main branch, specifically for changes <br>in the <code>client/**</code> path.<br> <li> Utilizes Netlify CLI for deployment, with environment variables for <br>authentication and site ID.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/551/files#diff-47afda0cc295898afc89d59105c7f9d37f2a6f98488af54b3a9aa9ba80e8386e">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

