### PR TITLE
fix(account): show extrinsics in account page

### DIFF
--- a/client/src/Account/components/AccountExtrinsicList.tsx
+++ b/client/src/Account/components/AccountExtrinsicList.tsx
@@ -59,10 +59,6 @@ const ExtrinsicList: FC<Props> = ({ accountId }) => {
     return <Spinner />
   }
 
-  if (selectedChain.title !== 'Gemini 3g' || selectedChain.isDomain) {
-    return <NotAllowed />
-  }
-
   const extrinsicsConnection = data.extrinsicsConnection.edges.map((extrinsic) => extrinsic.node)
   const totalCount = data.extrinsicsConnection.totalCount
 

--- a/client/src/Account/components/AccountExtrinsicList.tsx
+++ b/client/src/Account/components/AccountExtrinsicList.tsx
@@ -17,7 +17,6 @@ import { ExtrinsicListCard } from 'Extrinsic/components'
 // common
 import { CopyButton, Spinner, StatusIcon } from 'common/components'
 import NewTable from 'common/components/NewTable'
-import NotAllowed from 'common/components/NotAllowed'
 import { PAGE_SIZE } from 'common/constants'
 import { downloadFullData, shortString } from 'common/helpers'
 import useDomains from 'common/hooks/useDomains'


### PR DESCRIPTION
## **User description**
Remove validation that only allowed to show extrinsics in gemini-3g network.


___

## **Type**
bug_fix


___

## **Description**
- Removed a condition that prevented the display of extrinsics in the account page for networks other than 'Gemini 3g'. Now, extrinsics are shown for all networks without restrictions.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccountExtrinsicList.tsx</strong><dd><code>Allow Display of Extrinsics for All Networks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/Account/components/AccountExtrinsicList.tsx
<li>Removed network-specific validation that restricted the display of <br>extrinsics to only the 'Gemini 3g' network.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/553/files#diff-32c1e8fbaee04611c55ed9d1cfdaeebedfd7fab0005aa1af654e58427635909a">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

