### PR TITLE
fix(accountSquid): double encoding

### DIFF
--- a/account-squid/src/account/utils.ts
+++ b/account-squid/src/account/utils.ts
@@ -72,7 +72,7 @@ export async function ensureAccountsExist(
   existingAccounts.forEach((account) => accounts.set(account.id, account));
 
   accountIds.forEach((id) => {
-    if (!accounts.has(id)) accounts.set(id, new Account({ id: encodeId(id) }));
+    if (!accounts.has(id)) accounts.set(id, new Account({ id }));
   });
 
   return accounts;


### PR DESCRIPTION
## **User description**
there was a double encoding happening on transaction indexing at block 241380


___

## **Type**
bug_fix


___

## **Description**
- Fixes an issue where account IDs were being double-encoded during the account creation process in the `account-squid` module. This correction ensures account IDs are handled correctly without unnecessary encoding.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Fix Double Encoding on Account Creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

account-squid/src/account/utils.ts
- Removed double encoding on account ID during account creation.



</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/561/files#diff-7b3a98fb35ae2c7d539ba5aad289e12a8e3c8ba12f0e441f5914274635e2ec83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

