### PR TITLE
fix(logIndex): add catch on error for failing block digest indexing

### DIFF
--- a/squid-blockexplorer/src/blocks/getLogs.ts
+++ b/squid-blockexplorer/src/blocks/getLogs.ts
@@ -1,21 +1,33 @@
-import { SubstrateBlock } from '@subsquid/substrate-processor';
+import { SubstrateBlock } from "@subsquid/substrate-processor";
 import { Block, Log } from "../model";
 import { Context } from "../processor";
-import { SystemDigestStorage } from '../types/storage';
-import { decodeLog } from './utils';
+import { SystemDigestStorage } from "../types/storage";
+import { decodeLog } from "./utils";
 
-export function getLogsFactory(ctx: Context, storageFactory: (ctx: Context, header: SubstrateBlock) => SystemDigestStorage) {
+export function getLogsFactory(
+  ctx: Context,
+  storageFactory: (ctx: Context, header: SubstrateBlock) => SystemDigestStorage
+) {
   return async function getLogs(header: SubstrateBlock, block: Block) {
     const storage = storageFactory(ctx, header);
-    const digest = await storage.asV0.get();
 
-    return digest.logs.map((log, index) => new Log({
-      id: `${block.id}-${index}`,
-      kind: log.__kind,
-      // uncast to access 'value' prop, which is not present on all DigestItems
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      value: decodeLog((log as any).value),
-      block,
-    }));
+    try {
+      const digest = await storage.asV0.get();
+
+      return digest.logs.map(
+        (log, index) =>
+          new Log({
+            id: `${block.id}-${index}`,
+            kind: log.__kind,
+            // uncast to access 'value' prop, which is not present on all DigestItems
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            value: decodeLog((log as any).value),
+            block,
+          })
+      );
+    } catch (error) {
+      ctx.log.error(`Failed to get logs for block ${block.height}: ${error}`);
+      return [];
+    }
   };
 }


### PR DESCRIPTION
Fixing this specific error:

```
{"code":-32000,"rpcConnection":0,"rpcUrl":"wss:", "rpcRequestId":0,"rpcMethod":"state_getStorageAt","stack":"RpcError: Client error: UnknownBlock: Header was not found in the database: 0x2cdef504b5b4961557e49b3e560b6ab4034ea9a14a8a39cb20be296b2445f104
```