### PR TITLE
Fix wallet provider API bug

### DIFF
--- a/explorer/src/components/Operator/ActionsModal.tsx
+++ b/explorer/src/components/Operator/ActionsModal.tsx
@@ -4,7 +4,6 @@ import { bigNumberToNumber, floatToStringWithDecimals, formatUnitsToNumber } fro
 import { sendGAEvent } from '@next/third-parties/google'
 import { Modal } from 'components/common/Modal'
 import { Field, FieldArray, Form, Formik, FormikState } from 'formik'
-import useDomains from 'hooks/useDomains'
 import useWallet from 'hooks/useWallet'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import * as Yup from 'yup'
@@ -42,7 +41,6 @@ interface FormValues {
 const AMOUNT_TO_SUBTRACT_FROM_MAX_AMOUNT = 0.0001
 
 export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
-  const { selectedChain } = useDomains()
   const { api, actingAccount, injector } = useWallet()
   const [formError, setFormError] = useState<string | null>(null)
   const [tokenDecimals, setTokenDecimals] = useState<number>(0)
@@ -83,21 +81,21 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
   })
 
   const loadData = useCallback(async () => {
-    if (!api || !api[selectedChain.urls.page]) return
+    if (!api) return
 
-    const properties = await api[selectedChain.urls.page].rpc.system.properties()
+    const properties = await api.rpc.system.properties()
     setTokenDecimals((properties.tokenDecimals.toPrimitive() as number[])[0])
     setTokenSymbol((properties.tokenSymbol.toJSON() as string[])[0])
-  }, [api, selectedChain])
+  }, [api])
 
   const loadWalletBalance = useCallback(async () => {
-    if (!api || !actingAccount || !api[selectedChain.urls.page]) return
+    if (!api || !actingAccount) return
 
-    const balance = await api[selectedChain.urls.page].query.system.account(actingAccount.address)
+    const balance = await api.query.system.account(actingAccount.address)
     setWalletBalance(
       formatUnitsToNumber((balance.toJSON() as { data: { free: string } }).data.free),
     )
-  }, [api, actingAccount, selectedChain])
+  }, [api, actingAccount])
 
   const handleClose = useCallback(() => {
     setFormError(null)
@@ -109,13 +107,13 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
       values: FormValues,
       resetForm: (nextState?: Partial<FormikState<FormValues>> | undefined) => void,
     ) => {
-      if (!api || !actingAccount || !injector || !api[selectedChain.urls.page])
+      if (!api || !actingAccount || !injector)
         return setFormError('We are not able to connect to the blockchain')
       if (!action.operatorId) return setFormError('Please select an operator to add funds to')
 
       try {
-        const block = await api[selectedChain.urls.page].rpc.chain.getBlock()
-        const hash = await api[selectedChain.urls.page].tx.domains
+        const block = await api.rpc.chain.getBlock()
+        const hash = await api.tx.domains
           .nominateOperator(
             action.operatorId.toString(),
             floatToStringWithDecimals(values.amount, tokenDecimals),
@@ -136,7 +134,7 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
         sendGAEvent({ event: 'nominateOperator-error', value: error })
       }
     },
-    [api, actingAccount, injector, action.operatorId, tokenDecimals, handleClose, selectedChain],
+    [api, actingAccount, injector, action.operatorId, tokenDecimals, handleClose],
   )
 
   const handleWithdraw = useCallback(
@@ -144,13 +142,13 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
       values: FormValues,
       resetForm: (nextState?: Partial<FormikState<FormValues>> | undefined) => void,
     ) => {
-      if (!api || !actingAccount || !injector || !api[selectedChain.urls.page])
+      if (!api || !actingAccount || !injector)
         return setFormError('We are not able to connect to the blockchain')
       if (!action.operatorId) return setFormError('Please select an operator to add funds to')
 
       try {
-        const block = await api[selectedChain.urls.page].rpc.chain.getBlock()
-        const hash = await api[selectedChain.urls.page].tx.domains
+        const block = await api.rpc.chain.getBlock()
+        const hash = await api.tx.domains
           .withdrawStake(
             action.operatorId,
             maxAmount === values.amount
@@ -170,26 +168,17 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
         sendGAEvent({ event: 'withdrawStake-error', value: error })
       }
     },
-    [
-      api,
-      actingAccount,
-      injector,
-      action.operatorId,
-      maxAmount,
-      tokenDecimals,
-      handleClose,
-      selectedChain,
-    ],
+    [api, actingAccount, injector, action.operatorId, maxAmount, tokenDecimals, handleClose],
   )
 
   const handleDeregister = useCallback(async () => {
-    if (!api || !actingAccount || !injector || !api[selectedChain.urls.page])
+    if (!api || !actingAccount || !injector)
       return setFormError('We are not able to connect to the blockchain')
     if (!action.operatorId) return setFormError('Please select an operator to add funds to')
 
     try {
-      const block = await api[selectedChain.urls.page].rpc.chain.getBlock()
-      const hash = await api[selectedChain.urls.page].tx.domains
+      const block = await api.rpc.chain.getBlock()
+      const hash = await api.tx.domains
         .deregisterOperator(action.operatorId)
         .signAndSend(actingAccount.address, { signer: injector.signer })
 
@@ -205,16 +194,16 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
       console.error('Error', error)
       sendGAEvent({ event: 'deregisterOperator-error', value: error })
     }
-  }, [actingAccount, action.operatorId, api, injector, handleClose, selectedChain])
+  }, [actingAccount, action.operatorId, api, injector, handleClose])
 
   const handleUnlockFunds = useCallback(async () => {
-    if (!api || !actingAccount || !injector || !api[selectedChain.urls.page])
+    if (!api || !actingAccount || !injector)
       return setFormError('We are not able to connect to the blockchain')
     if (!action.operatorId) return setFormError('Please select an operator to add funds to')
 
     try {
-      const block = await api[selectedChain.urls.page].rpc.chain.getBlock()
-      const hash = await api[selectedChain.urls.page].tx.domains
+      const block = await api.rpc.chain.getBlock()
+      const hash = await api.tx.domains
         .unlockFunds(action.operatorId)
         .signAndSend(actingAccount.address, { signer: injector.signer })
 
@@ -227,16 +216,16 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
       console.error('Error', error)
       sendGAEvent({ event: 'unlockFunds-error', value: error })
     }
-  }, [actingAccount, action.operatorId, api, injector, handleClose, selectedChain])
+  }, [actingAccount, action.operatorId, api, injector, handleClose])
 
   const handleUnlockOperator = useCallback(async () => {
-    if (!api || !actingAccount || !injector || !api[selectedChain.urls.page])
+    if (!api || !actingAccount || !injector)
       return setFormError('We are not able to connect to the blockchain')
     if (!action.operatorId) return setFormError('Please select an operator to add funds to')
 
     try {
-      const block = await api[selectedChain.urls.page].rpc.chain.getBlock()
-      const hash = await api[selectedChain.urls.page].tx.domains
+      const block = await api.rpc.chain.getBlock()
+      const hash = await api.tx.domains
         .unlockOperator(action.operatorId)
         .signAndSend(actingAccount.address, { signer: injector.signer })
 
@@ -249,7 +238,7 @@ export const ActionsModal: FC<Props> = ({ isOpen, action, onClose }) => {
       console.error('Error', error)
       sendGAEvent({ event: 'unlockFunds-error', value: error })
     }
-  }, [actingAccount, action.operatorId, api, injector, handleClose, selectedChain])
+  }, [actingAccount, action.operatorId, api, injector, handleClose])
 
   const ErrorPlaceholder = useMemo(
     () =>

--- a/explorer/src/components/Operator/OperatorStake.tsx
+++ b/explorer/src/components/Operator/OperatorStake.tsx
@@ -9,7 +9,6 @@ import { isHex } from '@polkadot/util'
 import { PreferredExtensionModal } from 'components/layout/PreferredExtensionModal'
 import { EXTERNAL_ROUTES } from 'constants/routes'
 import { Field, Form, Formik, FormikState } from 'formik'
-import useDomains from 'hooks/useDomains'
 import useMediaQuery from 'hooks/useMediaQuery'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
@@ -35,7 +34,6 @@ type Domain = {
 
 export const OperatorStake = () => {
   const [isOpen, setIsOpen] = useState(false)
-  const { selectedChain } = useDomains()
   const { api, actingAccount, subspaceAccount, injector } = useWallet()
   const [formError, setFormError] = useState<string | null>(null)
   const isDesktop = useMediaQuery('(min-width: 640px)')
@@ -54,12 +52,12 @@ export const OperatorStake = () => {
   }
 
   const loadDomains = useCallback(async () => {
-    if (!api || !api[selectedChain.urls.page]) return
+    if (!api) return
 
     const [domains, domainRegistry, properties] = await Promise.all([
-      api[selectedChain.urls.page].consts.domains,
-      api[selectedChain.urls.page].query.domains.domainRegistry.entries(),
-      api[selectedChain.urls.page].rpc.system.properties(),
+      api.consts.domains,
+      api.query.domains.domainRegistry.entries(),
+      api.rpc.system.properties(),
     ])
 
     setDomainsList(
@@ -78,7 +76,7 @@ export const OperatorStake = () => {
     setTokenDecimals(_tokenDecimals)
     setTokenSymbol((properties.tokenSymbol.toJSON() as string[])[0])
     setMinOperatorStake((domains.minOperatorStake.toPrimitive() as number) / 10 ** _tokenDecimals)
-  }, [api, selectedChain])
+  }, [api])
 
   const filteredDomainsList = useMemo(
     () =>
@@ -133,12 +131,12 @@ export const OperatorStake = () => {
       values: FormValues,
       resetForm: (nextState?: Partial<FormikState<FormValues>> | undefined) => void,
     ) => {
-      if (!api || !actingAccount || !injector || !api[selectedChain.urls.page])
+      if (!api || !actingAccount || !injector)
         return setFormError('We are not able to connect to the blockchain')
 
       try {
-        const block = await api[selectedChain.urls.page].rpc.chain.getBlock()
-        const hash = await api[selectedChain.urls.page].tx.domains
+        const block = await api.rpc.chain.getBlock()
+        const hash = await api.tx.domains
           .registerOperator(
             values.domainId,
             floatToStringWithDecimals(values.amountToStake, tokenDecimals),
@@ -163,7 +161,7 @@ export const OperatorStake = () => {
       }
       resetForm()
     },
-    [actingAccount, api, injector, tokenDecimals, selectedChain],
+    [actingAccount, api, injector, tokenDecimals],
   )
 
   const handleConnectWallet = useCallback((e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/explorer/src/components/WalletSideKick/index.tsx
+++ b/explorer/src/components/WalletSideKick/index.tsx
@@ -88,7 +88,6 @@ const Drawer: FC<DrawerProps> = ({ isOpen, onClose }) => {
     () => chains.find((chain) => chain.urls.page === selectedChain.urls.page) ?? chains[0],
     [selectedChain],
   )
-  const consensusApi = useMemo(() => api && api[consensusChain.urls.page], [api, consensusChain])
 
   const handleNavigate = useCallback(
     (url: string) => {
@@ -99,28 +98,28 @@ const Drawer: FC<DrawerProps> = ({ isOpen, onClose }) => {
   )
 
   const loadData = useCallback(async () => {
-    if (!consensusApi) return
+    if (!api) return
 
-    const properties = await consensusApi.rpc.system.properties()
+    const properties = await api.rpc.system.properties()
     setTokenSymbol((properties.tokenSymbol.toJSON() as string[])[0])
-  }, [consensusApi])
+  }, [api])
 
   const loadWalletBalance = useCallback(async () => {
-    if (!consensusApi || !actingAccount) return
+    if (!api || !actingAccount) return
 
-    const balance = await consensusApi.query.system.account(actingAccount.address)
+    const balance = await api.query.system.account(actingAccount.address)
     setWalletBalance(
       formatUnitsToNumber((balance.toJSON() as { data: { free: string } }).data.free),
     )
-  }, [consensusApi, actingAccount])
+  }, [api, actingAccount])
 
   useEffect(() => {
     loadData()
-  }, [consensusApi, loadData])
+  }, [api, loadData])
 
   useEffect(() => {
     loadWalletBalance()
-  }, [consensusApi, actingAccount, loadWalletBalance])
+  }, [api, actingAccount, loadWalletBalance])
 
   if (!subspaceAccount || !actingAccount) return null
 


### PR DESCRIPTION
### **User description**
## Fix wallet provider API bug

As mention in #609 and reported by @randywessels


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed `useDomains` hook and its references across multiple components.
- Simplified API calls by removing dependencies on `selectedChain` and `consensusApi`.
- Improved error handling for blockchain connection in various components.
- Refactored `WalletProvider` to handle a single chain and improved error handling during API preparation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ActionsModal.tsx</strong><dd><code>Simplify API calls and improve error handling in ActionsModal.</code></dd></summary>
<hr>

explorer/src/components/Operator/ActionsModal.tsx
<li>Removed <code>useDomains</code> hook and its references.<br> <li> Simplified API calls by removing <code>selectedChain</code> dependency.<br> <li> Improved error handling for blockchain connection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/610/files#diff-c51e982ee70748b2febca1c00569a9e2ce296b1945217fe74880c83284730690">+26/-37</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OperatorStake.tsx</strong><dd><code>Simplify API calls and improve error handling in OperatorStake.</code></dd></summary>
<hr>

explorer/src/components/Operator/OperatorStake.tsx
<li>Removed <code>useDomains</code> hook and its references.<br> <li> Simplified API calls by removing <code>selectedChain</code> dependency.<br> <li> Improved error handling for blockchain connection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/610/files#diff-6f4586d33db827f18f269282deb73cc3c97bfb1ae24e414674ab456f4b73d691">+9/-11</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ActionsModal.tsx</strong><dd><code>Simplify API calls and improve error handling in WalletSideKick </code><br><code>ActionsModal.</code></dd></summary>
<hr>

explorer/src/components/WalletSideKick/ActionsModal.tsx
<li>Removed <code>chains</code> import and its references.<br> <li> Simplified API calls by removing <code>consensusApi</code> dependency.<br> <li> Improved error handling for blockchain connection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/610/files#diff-07aae665e5d24aa2a97f9a487e9bf8c95ca428178cc1f7e5af927f4c01658763">+16/-22</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Simplify API calls and improve error handling in WalletSideKick index.</code></dd></summary>
<hr>

explorer/src/components/WalletSideKick/index.tsx
<li>Removed <code>consensusApi</code> dependency.<br> <li> Simplified API calls by directly using <code>api</code>.<br> <li> Improved error handling for blockchain connection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/610/files#diff-04afecfb82054a461cae9c2d39d5f4b4348149a77d548bb44afe946a1acdffca">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WalletProvider.tsx</strong><dd><code>Refactor WalletProvider to handle a single chain and improve error </code><br><code>handling.</code></dd></summary>
<hr>

explorer/src/providers/WalletProvider.tsx
<li>Changed <code>api</code> state to hold a single <code>ApiPromise</code> instance.<br> <li> Updated <code>prepareApi</code> and <code>setup</code> functions to handle a single chain.<br> <li> Improved error handling for API preparation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/610/files#diff-cc6aab1a37127db0ca205368adb225f38c5e87ec950a13b830d2cd14f19c2cdd">+20/-20</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

