### PR TITLE
fix small bug that creped in during merge conflict

### DIFF
--- a/explorer/src/components/Operator/OperatorStake.tsx
+++ b/explorer/src/components/Operator/OperatorStake.tsx
@@ -496,15 +496,15 @@ export const OperatorStake = () => {
                             <>
                               <div className={`p-4 ${isDesktop ? 'col-span-2' : 'col-span-1'}`}>
                                 <span className='text-base font-medium text-grayDarker dark:text-white'>
-                                  Signing key
+                                  Signing key seed
                                 </span>
                                 <Field
-                                  name='signingKey'
-                                  placeholder='Signing Key'
+                                  name='signingKeySeed'
+                                  placeholder='Signing Key seed'
                                   className={`mt-4 block w-full rounded-full bg-white from-pinkAccent to-purpleDeepAccent px-4 py-[10px] text-sm text-gray-900 shadow-lg dark:bg-gradient-to-r dark:text-white
                             ${
-                              errors.signingKey &&
-                              touched.signingKey &&
+                              errors.signingKeySeed &&
+                              touched.signingKeySeed &&
                               'block w-full rounded-full bg-white px-4 py-[10px] text-sm text-gray-900 shadow-lg dark:bg-blueDarkAccent'
                             }
                           `}


### PR DESCRIPTION
### **User description**
## fix small bug that creped in during merge conflict


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected the naming of the `signingKey` field to `signingKeySeed` in the `OperatorStake` component.
- Updated the placeholder text and error handling to match the new field name.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OperatorStake.tsx</strong><dd><code>Fix naming inconsistency for signing key seed field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Operator/OperatorStake.tsx
<li>Corrected the naming of the <code>signingKey</code> field to <code>signingKeySeed</code>.<br> <li> Updated placeholder text to match the new field name.<br> <li> Adjusted error handling to reflect the new field name.<br>


</details>
    

  </td>
  <td><a href="https://github.com/subspace/astral/pull/669/files#diff-6f4586d33db827f18f269282deb73cc3c97bfb1ae24e414674ab456f4b73d691">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

