### PR TITLE
add --max-old-space-size in process command

### DIFF
--- a/indexers/general-squid/commands.json
+++ b/indexers/general-squid/commands.json
@@ -51,7 +51,12 @@
     "process": {
       "description": "Load .env and start the squid processor",
       "deps": ["build", "migration:apply"],
-      "cmd": ["node", "--require=dotenv/config", "lib/main.js"]
+      "cmd": [
+        "node",
+        "--max-old-space-size=4096",
+        "--require=dotenv/config",
+        "lib/main.js"
+      ]
     },
     "process:prod": {
       "description": "Start the squid processor",


### PR DESCRIPTION
### **User description**
## add --max-old-space-size in process command

This is to try to improve/fix the process of hitting a panic error due to the max memory reached in node thread.

___

### **PR Type**
enhancement


___

### **Description**
- Added `--max-old-space-size=4096` option to the `process` command to increase the memory limit.
- Reformatted the `cmd` array for better readability and maintainability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.json</strong><dd><code>Increase memory limit for the `process` command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/general-squid/commands.json

<li>Added <code>--max-old-space-size=4096</code> option to the <code>process</code> command.<br> <li> Reformatted the <code>cmd</code> array for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/680/files#diff-dfca0b559421648eeb9280e42f68bb417f8522d62e01a1eb27b1bc519c033807">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

