### PR TITLE
re-order chains

### DIFF
--- a/explorer/src/constants/chains.ts
+++ b/explorer/src/constants/chains.ts
@@ -26,24 +26,6 @@ export interface Chain {
 
 export const chains: Chain[] = [
   {
-    title: 'Localhost',
-    urls: {
-      rpc: 'ws://127.0.0.1:9944/ws',
-      page: Chains.localhost,
-      squids: {
-        old: 'http://localhost:4349/graphql',
-        general: 'http://localhost:4350/graphql',
-        rewards: 'http://localhost:4351/graphql',
-        account: 'http://localhost:4352/graphql',
-      },
-    },
-    token: {
-      symbol: 'tSSC',
-      decimals: 18,
-    },
-    isDomain: false,
-  },
-  {
     title: 'Gemini 3h',
     urls: {
       rpc: 'wss://rpc-0.gemini-3h.subspace.network/ws',
@@ -68,6 +50,24 @@ export const chains: Chain[] = [
       page: Chains.gemini3g,
       squids: {
         old: 'https://squid.gemini-3g.subspace.network/graphql',
+      },
+    },
+    token: {
+      symbol: 'tSSC',
+      decimals: 18,
+    },
+    isDomain: false,
+  },
+  {
+    title: 'Localhost',
+    urls: {
+      rpc: 'ws://127.0.0.1:9944/ws',
+      page: Chains.localhost,
+      squids: {
+        old: 'http://localhost:4349/graphql',
+        general: 'http://localhost:4350/graphql',
+        rewards: 'http://localhost:4351/graphql',
+        account: 'http://localhost:4352/graphql',
       },
     },
     token: {


### PR DESCRIPTION
### **User description**
## re-order chains

Some code consider chains[0] the default chain and therefore can create error having localhost as chains[0]


___

### **PR Type**
Bug fix


___

### **Description**
- Re-ordered the `chains` array in `explorer/src/constants/chains.ts` to move the 'Localhost' chain from the first position to the last. This prevents potential errors caused by defaulting to the localhost chain.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chains.ts</strong><dd><code>Re-order `chains` array to avoid defaulting to localhost</code>&nbsp; </dd></summary>
<hr>

explorer/src/constants/chains.ts

<li>Re-ordered the <code>chains</code> array to move the 'Localhost' chain from the <br>first position to the last.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/699/files#diff-eb63a5eddc5a84bbe18f0e284e13bd693e6f8ab78ae82e84d8cec57bb4f4dd12">+18/-18</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

