### PR TITLE
fix domain name on Managing page

### DIFF
--- a/explorer/src/components/Operator/OperatorManagement.tsx
+++ b/explorer/src/components/Operator/OperatorManagement.tsx
@@ -12,11 +12,13 @@ import { Chains, PAGE_SIZE } from 'constants/'
 import { INTERNAL_ROUTES } from 'constants/routes'
 import { OperatorsConnectionQuery } from 'gql/graphql'
 import useDomains from 'hooks/useDomains'
+import { useDomainsData } from 'hooks/useDomainsData'
 import useMediaQuery from 'hooks/useMediaQuery'
 import useWallet from 'hooks/useWallet'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useErrorHandler } from 'react-error-boundary'
+import { useDomainsStates } from 'states/domains'
 import type { Cell } from 'types/table'
 import { downloadFullData } from 'utils/downloadFullData'
 import { operatorReadyToUnlock, operatorStatus } from 'utils/operator'
@@ -36,6 +38,8 @@ export const OperatorManagement: FC = () => {
   const isDesktop = useMediaQuery('(min-width: 640px)')
 
   const { subspaceAccount } = useWallet()
+  const { domains } = useDomainsStates()
+  const { loadData: loadDomainsData } = useDomainsData()
   const { selectedChain, selectedDomain } = useDomains()
   const apolloClient = useApolloClient()
 
@@ -45,6 +49,10 @@ export const OperatorManagement: FC = () => {
     maxShares: null,
   })
   const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (!domains || domains.length === 0) loadDomainsData()
+  }, [domains, loadDomainsData])
 
   const handleAction = useCallback((value: OperatorAction) => {
     setAction(value)
@@ -192,9 +200,20 @@ export const OperatorManagement: FC = () => {
         enableSorting: true,
         cell: ({
           row,
-        }: Cell<OperatorsConnectionQuery['operatorsConnection']['edges'][0]['node']>) => (
-          <div>{row.original.currentDomainId === 0 ? 'Subspace' : 'Nova'}</div>
-        ),
+        }: Cell<OperatorsConnectionQuery['operatorsConnection']['edges'][0]['node']>) => {
+          const domain = domains.find(
+            (d) =>
+              (row.original.currentDomainId || row.original.currentDomainId === 0) &&
+              d.domainId === row.original.currentDomainId.toString(),
+          )
+          return (
+            <div>
+              {domain
+                ? domain.domainName.charAt(0).toUpperCase() + domain.domainName.slice(1)
+                : '#' + row.original.currentDomainId}
+            </div>
+          )
+        },
       },
       {
         accessorKey: 'signingKey',


### PR DESCRIPTION
### **User description**
## fix domain name on Managing page


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added import statements for `useDomainsData` and `useDomainsStates` in `NominationManagement.tsx` and `OperatorManagement.tsx`.
- Integrated domain data loading using `useDomainsData` and `useDomainsStates` in both components.
- Updated domain display logic to use the correct domain name instead of hardcoded values.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NominationManagement.tsx</strong><dd><code>Fix and enhance domain name display logic in NominationManagement</code></dd></summary>
<hr>

explorer/src/components/Operator/NominationManagement.tsx

<li>Added import statements for <code>useDomainsData</code> and <code>useDomainsStates</code>.<br> <li> Integrated domain data loading using <code>useDomainsData</code> and <br><code>useDomainsStates</code>.<br> <li> Updated domain display logic to use the correct domain name.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/704/files#diff-efeab9f927b13d2314b3f2712da012a7368455850b73a81f40c4ea18408a49d0">+23/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OperatorManagement.tsx</strong><dd><code>Fix and enhance domain name display logic in OperatorManagement</code></dd></summary>
<hr>

explorer/src/components/Operator/OperatorManagement.tsx

<li>Added import statements for <code>useDomainsData</code> and <code>useDomainsStates</code>.<br> <li> Integrated domain data loading using <code>useDomainsData</code> and <br><code>useDomainsStates</code>.<br> <li> Updated domain display logic to use the correct domain name.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/704/files#diff-1728839c747fa9b636fe04951d7342836b3786430d6640d8bd9bd9ca72e9c8e3">+22/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

