### PR TITLE
Only filter out double quote character in keystore

### DIFF
--- a/explorer/src/components/Operator/OperatorStake.tsx
+++ b/explorer/src/components/Operator/OperatorStake.tsx
@@ -250,7 +250,7 @@ export const OperatorStake = () => {
           const keystoreContent = fileReader.result as string
           if (fileReader.readyState === 2) {
             try {
-              const seed = keystoreContent.replace(/"|_/g, '')
+              const seed = keystoreContent.replace(/"/g, '')
               setFieldValue('signingKeySeed', seed)
             } catch (error) {
               setFormError('There was an error with the keystore')


### PR DESCRIPTION
### **User description**
## Only filter out double quote character in keystore


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the keystore content filtering logic to exclude only double quote characters instead of both double quotes and underscores.
- Ensured that the signing key seed is correctly set without removing underscores from the keystore content.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OperatorStake.tsx</strong><dd><code>Fix keystore content filtering to exclude only double quotes</code></dd></summary>
<hr>

explorer/src/components/Operator/OperatorStake.tsx

<li>Modified the <code>replace</code> function to only filter out double quote <br>characters.<br> <li> Removed the underscore character from the <code>replace</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/708/files#diff-6f4586d33db827f18f269282deb73cc3c97bfb1ae24e414674ab456f4b73d691">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

