### PR TITLE
stop the wallet sidekick from rendering children components when close

### DIFF
--- a/explorer/src/components/WalletSideKick/index.tsx
+++ b/explorer/src/components/WalletSideKick/index.tsx
@@ -169,6 +169,7 @@ const Drawer: FC<DrawerProps> = ({ isOpen, onClose }) => {
     loadWalletBalance()
   }, [api, actingAccount, loadWalletBalance])
 
+  if (!isOpen) return null
   if (!actingAccount) return null
 
   return (


### PR DESCRIPTION
### **User description**
## stop the wallet sidekick from rendering children components when close


___

### **PR Type**
Bug fix


___

### **Description**
- Added a condition to prevent the WalletSideKick component from rendering its children when it is closed.
- This change ensures that unnecessary rendering does not occur when the component is not visible.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Prevent rendering of WalletSideKick children when closed</code>&nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/index.tsx

- Added a condition to return null if `isOpen` is false.



</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/709/files#diff-04afecfb82054a461cae9c2d39d5f4b4348149a77d548bb44afe946a1acdffca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

