### PR TITLE
Remove fromNow logic on extrinsic and event count cells

### DIFF
--- a/explorer/src/components/Block/BlockList.tsx
+++ b/explorer/src/components/Block/BlockList.tsx
@@ -102,9 +102,7 @@ export const BlockList: FC = () => {
         header: 'Extrinsics',
         enableSorting: false,
         cell: ({ row }: Cell<Block>) => (
-          <div key={`${row.index}-block-time`}>
-            {dayjs(row.original.extrinsics?.length).fromNow(true)}
-          </div>
+          <div key={`${row.index}-block-time`}>{row.original.extrinsics?.length}</div>
         ),
       },
       {
@@ -112,9 +110,7 @@ export const BlockList: FC = () => {
         header: 'Events',
         enableSorting: false,
         cell: ({ row }: Cell<Block>) => (
-          <div key={`${row.index}-block-time`}>
-            {dayjs(row.original.events?.length).fromNow(true)}
-          </div>
+          <div key={`${row.index}-block-time`}>{row.original.events?.length}</div>
         ),
       },
       {


### PR DESCRIPTION
### **User description**
Extrinsic and event counts on Blocks page were had `fromNow` logic instead of just counts. Removed this logic and counts are now showing properly.
![image](https://github.com/user-attachments/assets/67b8977a-fcac-4b2b-a2e8-275961f64160)


___

### **PR Type**
Bug fix


___

### **Description**
- Removed `fromNow` logic from extrinsic count cell in `BlockList` component.
- Removed `fromNow` logic from event count cell in `BlockList` component.
- Now displaying raw counts for extrinsics and events instead of relative time.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BlockList.tsx</strong><dd><code>Remove `fromNow` logic from extrinsic and event count cells</code></dd></summary>
<hr>

explorer/src/components/Block/BlockList.tsx

<li>Removed <code>fromNow</code> logic from extrinsic count cell.<br> <li> Removed <code>fromNow</code> logic from event count cell.<br> <li> Displaying raw counts for extrinsics and events.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/713/files#diff-de5790ac6b69c264caeabf301585f9aca69aee5cc3dcbb069e8e942c0ee3f3e4">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

