### PR TITLE
Add out of sync banner

### DIFF
--- a/explorer/gql/oldSquidTypes.ts
+++ b/explorer/gql/oldSquidTypes.ts
@@ -2792,3 +2792,8 @@ export type CheckRoleQueryVariables = Exact<{
 
 
 export type CheckRoleQuery = { __typename?: 'Query', isFarmer: Array<{ __typename?: 'RewardEvent', account?: { __typename?: 'Account', id: string } | null }> };
+
+export type LastBlockQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LastBlockQuery = { __typename?: 'Query', lastBlock: Array<{ __typename?: 'Block', height: any }> };

--- a/explorer/src/components/common/OutOfSyncBanner.tsx
+++ b/explorer/src/components/common/OutOfSyncBanner.tsx
@@ -1,0 +1,64 @@
+import { useQuery } from '@apollo/client'
+import { activate } from '@autonomys/auto-utils'
+import { LastBlockQuery } from 'gql/oldSquidTypes'
+import useDomains from 'hooks/useDomains'
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { LAST_BLOCK } from './query'
+
+const NORMAL_BLOCKS_DIVERGENCE = 120
+
+export const OutOfSyncBanner: FC = () => {
+  return (
+    <div className="container mx-auto mb-4 flex grow justify-center px-5 font-['Montserrat'] md:px-[25px] 2xl:px-0">
+      <div className='sticky top-0 z-50 w-full'>
+        <div className='w-full rounded-[20px] bg-[#DDEFF1] p-5 shadow dark:border-none dark:bg-gradient-to-r dark:from-[#4141B3] dark:via-[#6B5ACF] dark:to-[#896BD2]'>
+          <div className='flex flex-col gap-4'>
+            <div className='text-[20px] font-bold text-[#282929] dark:text-white'>
+              Indexer Currently Out of Sync
+            </div>
+            <div className='text-[15px] text-[#282929] dark:text-white'>
+              The indexer is currently out of sync. We are working to resolve this issue as soon as
+              possible. Please check back later.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const useOutOfSyncBanner = () => {
+  const { selectedChain } = useDomains()
+  const [lastChainBlock, setLastChainBlock] = useState<number | null>(null)
+
+  const { data } = useQuery<LastBlockQuery>(LAST_BLOCK, {
+    pollInterval: 6000,
+  })
+
+  const getChainLastBlock = useCallback(async () => {
+    const api = await activate({ networkId: 'autonomys-' + selectedChain?.urls.page })
+
+    const block = await api.rpc.chain.getBlock()
+
+    setLastChainBlock(block.block.header.number.toNumber())
+  }, [selectedChain])
+
+  const lastBlock = useMemo(() => data && parseInt(data.lastBlock[0].height), [data])
+
+  const outOfSyncBanner = useMemo(
+    () =>
+      data &&
+      lastBlock &&
+      lastChainBlock !== null &&
+      lastBlock + NORMAL_BLOCKS_DIVERGENCE < lastChainBlock ? (
+        <OutOfSyncBanner />
+      ) : null,
+    [data, lastBlock, lastChainBlock],
+  )
+
+  useEffect(() => {
+    getChainLastBlock()
+  }, [getChainLastBlock])
+
+  return outOfSyncBanner
+}

--- a/explorer/src/components/common/OutOfSyncBanner.tsx
+++ b/explorer/src/components/common/OutOfSyncBanner.tsx
@@ -1,7 +1,9 @@
 import { useQuery } from '@apollo/client'
 import { activate } from '@autonomys/auto-utils'
+import { EXTERNAL_ROUTES } from 'constants/routes'
 import { LastBlockQuery } from 'gql/oldSquidTypes'
 import useDomains from 'hooks/useDomains'
+import Link from 'next/link'
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { LAST_BLOCK } from './query'
 
@@ -18,7 +20,20 @@ export const OutOfSyncBanner: FC = () => {
             </div>
             <div className='text-[15px] text-[#282929] dark:text-white'>
               The indexer is currently out of sync. We are working to resolve this issue as soon as
-              possible. Please check back later.
+              possible. Please check back later or visit Subscan for the most up-to-date information
+              or use Polkadot.js Apps to interact with the chain.
+            </div>
+            <div>
+              <Link href={EXTERNAL_ROUTES.subscan} target='_blank'>
+                <button className='self-start rounded-[20px] bg-white px-[33px] py-[13px] text-sm font-medium text-gray-800 hover:bg-gray-200 dark:bg-[#1E254E] dark:text-white'>
+                  Visit Subscan
+                </button>
+              </Link>
+              <Link className='ml-4' href={EXTERNAL_ROUTES.polkadot} target='_blank'>
+                <button className='self-start rounded-[20px] bg-white px-[33px] py-[13px] text-sm font-medium text-gray-800 hover:bg-gray-200 dark:bg-[#1E254E] dark:text-white'>
+                  Visit Polkadot.js Apps
+                </button>
+              </Link>
             </div>
           </div>
         </div>

--- a/explorer/src/components/common/query.ts
+++ b/explorer/src/components/common/query.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client'
+
+export const LAST_BLOCK = gql`
+  query LastBlock {
+    lastBlock: blocks(limit: 1, orderBy: height_DESC) {
+      height
+    }
+  }
+`

--- a/explorer/src/components/layout/Layout.tsx
+++ b/explorer/src/components/layout/Layout.tsx
@@ -27,6 +27,7 @@ export const MainLayout: FC<Props> = ({ children, subHeader }) => {
   return (
     <div className="relative flex min-h-screen w-full flex-col bg-gradient-to-b from-bronze to-purpleMist font-['Montserrat'] dark:bg-dark">
       <div className="relative flex min-h-screen w-full flex-col bg-[url('/images/backgroundColor.svg')] bg-cover font-['Montserrat']">
+        {outOfSync}
         <DomainHeader />
         {subHeader}
         <ErrorBoundary
@@ -35,7 +36,6 @@ export const MainLayout: FC<Props> = ({ children, subHeader }) => {
           // TODO: consider adding error monitoring
           onError={(error) => console.error(error)}
         >
-          {outOfSync}
           <Container>{children}</Container>
         </ErrorBoundary>
         <Footer />

--- a/explorer/src/components/layout/Layout.tsx
+++ b/explorer/src/components/layout/Layout.tsx
@@ -3,6 +3,7 @@
 import Footer from '@/components/layout/Footer'
 import { CookieBanner } from 'components/common/CookieBanner'
 import { ErrorFallback } from 'components/common/ErrorFallback'
+import { useOutOfSyncBanner } from 'components/common/OutOfSyncBanner'
 import { Container } from 'components/layout/Container'
 import { DomainHeader } from 'components/layout/DomainHeader'
 import { usePathname } from 'next/navigation'
@@ -17,13 +18,14 @@ type Props = {
 
 export const MainLayout: FC<Props> = ({ children, subHeader }) => {
   const pathname = usePathname()
+  const outOfSync = useOutOfSyncBanner()
 
   useEffect(() => {
     ReactGA.send({ hitType: 'pageview', page: pathname })
   }, [pathname])
 
   return (
-    <div className="from-bronze to-purpleMist relative flex min-h-screen w-full flex-col bg-gradient-to-b font-['Montserrat'] dark:bg-dark">
+    <div className="relative flex min-h-screen w-full flex-col bg-gradient-to-b from-bronze to-purpleMist font-['Montserrat'] dark:bg-dark">
       <div className="relative flex min-h-screen w-full flex-col bg-[url('/images/backgroundColor.svg')] bg-cover font-['Montserrat']">
         <DomainHeader />
         {subHeader}
@@ -33,6 +35,7 @@ export const MainLayout: FC<Props> = ({ children, subHeader }) => {
           // TODO: consider adding error monitoring
           onError={(error) => console.error(error)}
         >
+          {outOfSync}
           <Container>{children}</Container>
         </ErrorBoundary>
         <Footer />


### PR DESCRIPTION
### **User description**
## Add out of sync banner

![image (1)](https://github.com/user-attachments/assets/0513733f-8996-4777-9693-75f930cb1566)


___

### **PR Type**
Enhancement


___

### **Description**
- Added `LastBlockQueryVariables` and `LastBlockQuery` types in `oldSquidTypes.ts`.
- Created `OutOfSyncBanner` component and `useOutOfSyncBanner` hook in `OutOfSyncBanner.tsx`.
- Added GraphQL query for fetching the last block in `query.ts`.
- Integrated `useOutOfSyncBanner` hook into the main layout in `Layout.tsx`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>oldSquidTypes.ts</strong><dd><code>Add GraphQL types for last block query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/gql/oldSquidTypes.ts

- Added `LastBlockQueryVariables` and `LastBlockQuery` types.



</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/715/files#diff-a23a48a4f993d1a31525786fcd25244ae5bde2019dc196349079e1a7d6aae9d0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OutOfSyncBanner.tsx</strong><dd><code>Implement Out of Sync Banner component and hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/common/OutOfSyncBanner.tsx

<li>Created <code>OutOfSyncBanner</code> component.<br> <li> Implemented <code>useOutOfSyncBanner</code> hook to fetch and display the banner.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/715/files#diff-4babc9c3a2f6222cf07962354c5e6fcc136efad5de58d0096229ab9b1c74e13d">+64/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Add GraphQL query for last block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/common/query.ts

- Added GraphQL query for fetching the last block.



</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/715/files#diff-4e4321812d87ecba37f4fa3290fc5e83e800c30e317334ed807c4e2f424c317e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Layout.tsx</strong><dd><code>Integrate Out of Sync Banner into main layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/layout/Layout.tsx

- Integrated `useOutOfSyncBanner` hook into the main layout.



</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/715/files#diff-d3a55ba608ad601d6b87f935e74bdef795050af0998deb7aac09a669d568c41e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

