### PR TITLE
Fix the account icon next to signing key to show your own op

### DIFF
--- a/explorer/src/components/Operator/OperatorsList.tsx
+++ b/explorer/src/components/Operator/OperatorsList.tsx
@@ -31,6 +31,7 @@ import { operatorStatus } from 'utils/operator'
 import { sort } from 'utils/sort'
 import { capitalizeFirstLetter, shortString } from 'utils/string'
 import { AccountIcon } from '../common/AccountIcon'
+import { Tooltip } from '../common/Tooltip'
 import { NotFound } from '../layout/NotFound'
 import { ActionsDropdown, ActionsDropdownRow } from './ActionsDropdown'
 import { ActionsModal, OperatorAction, OperatorActionType } from './ActionsModal'
@@ -87,7 +88,6 @@ export const OperatorsList: FC = () => {
           row,
         }: Cell<OperatorsConnectionQuery['operatorsConnection']['edges'][0]['node']>) => (
           <Link
-            data-testid={`operator-link-${row.original.id}-${row.original.signingKey}-${row.index}}`}
             className='hover:text-purpleAccent'
             href={INTERNAL_ROUTES.operators.id.page(
               selectedChain.urls.page,
@@ -129,7 +129,9 @@ export const OperatorsList: FC = () => {
         }: Cell<OperatorsConnectionQuery['operatorsConnection']['edges'][0]['node']>) => (
           <div className='row flex items-center gap-3'>
             {row.original.operatorOwner === subspaceAccount && (
-              <AccountIcon address={row.original.id} size={26} />
+              <Tooltip text='You are the operator'>
+                <AccountIcon address={row.original.operatorOwner} size={26} />
+              </Tooltip>
             )}
             <div>{shortString(row.original.signingKey)}</div>
           </div>


### PR DESCRIPTION
### **User description**
## Fix the account icon next to signing key to show your own op

![image](https://github.com/user-attachments/assets/f2688c56-d7d2-4357-b85c-a1bc0e14092f)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a `Tooltip` component to display a message when hovering over the account icon, indicating that the user is the operator.
- Fixed the account icon to correctly show the operator's own address instead of the ID.
- Removed an unnecessary `data-testid` attribute from the `Link` component for cleaner code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OperatorsList.tsx</strong><dd><code>Fix and enhance account icon display with tooltip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Operator/OperatorsList.tsx

<li>Added <code>Tooltip</code> component to display a tooltip when hovering over the <br>account icon.<br> <li> Fixed the account icon to show the operator's own address.<br> <li> Removed unnecessary <code>data-testid</code> attribute from the <code>Link</code> component.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/728/files#diff-2144a16cae24f1edb0774bfb0c1d2db81bf6100af1920189a1b1dbda4506bdaf">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

