### PR TITLE
improve DB indexing for squid

### DIFF
--- a/indexers/squid-blockexplorer/schema.graphql
+++ b/indexers/squid-blockexplorer/schema.graphql
@@ -5,8 +5,8 @@ type Account @entity {
   total: BigInt @index
   updatedAt: BigInt
   nonce: BigInt
-  extrinsics: [Extrinsic!]! @derivedFrom(field: "signer") @cardinality(value: 10)
-  rewards: [RewardEvent!]! @derivedFrom(field: "account") @cardinality(value: 10)
+  extrinsics: [Extrinsic!]! @derivedFrom(field: "signer") @cardinality(value: 10) @index
+  rewards: [RewardEvent!]! @derivedFrom(field: "account") @cardinality(value: 10) @index
 }
 
 type Block @entity {
@@ -42,7 +42,7 @@ type Extrinsic @entity {
   nonce: BigInt
   name: String!
   signer: Account @index
-  signature: String
+  signature: String @index
   error: JSON
   tip: BigInt
   fee: BigInt
@@ -148,5 +148,5 @@ type AccountRewards @entity {
 type OperatorRewards @entity {
   id: ID! @index
   amount: BigInt
-  updatedAt: BigInt!
+  updatedAt: BigInt! @index
 }

--- a/indexers/squid-blockexplorer/schema.graphql
+++ b/indexers/squid-blockexplorer/schema.graphql
@@ -40,7 +40,7 @@ type Extrinsic @entity {
   hash: String! @index
   indexInBlock: Int!
   nonce: BigInt
-  name: String!
+  name: String! @index
   signer: Account @index
   signature: String @index
   error: JSON
@@ -63,7 +63,7 @@ type EventModuleName @entity {
 type Event @entity {
   id: ID! @index
   indexInBlock: Int!
-  name: String!
+  name: String! @index
   timestamp: DateTime! @index
   phase: String!
   pos: Int
@@ -76,7 +76,7 @@ type Event @entity {
 type RewardEvent @entity {
   id: ID! @index
   indexInBlock: Int!
-  name: String!
+  name: String! @index
   timestamp: DateTime! @index
   phase: String!
   pos: Int
@@ -89,7 +89,7 @@ type RewardEvent @entity {
 
 type Call @entity {
   id: ID! @index
-  name: String!
+  name: String! @index
   timestamp: DateTime! @index
   success: Boolean!
   args: JSON

--- a/indexers/squid-blockexplorer/schema.graphql
+++ b/indexers/squid-blockexplorer/schema.graphql
@@ -5,37 +5,29 @@ type Account @entity {
   total: BigInt @index
   updatedAt: BigInt
   nonce: BigInt
-  extrinsics: [Extrinsic!]!
-    @derivedFrom(field: "signer")
-    @cardinality(value: 10)
-  rewards: [RewardEvent!]!
-    @derivedFrom(field: "account")
-    @cardinality(value: 10)
+  extrinsics: [Extrinsic!]! @derivedFrom(field: "signer") @cardinality(value: 10)
+  rewards: [RewardEvent!]! @derivedFrom(field: "account") @cardinality(value: 10)
 }
 
 type Block @entity {
   id: ID! @index
   height: BigInt! @index
-  timestamp: DateTime!
-  hash: String!
+  timestamp: DateTime! @index
+  hash: String! @index
   parentHash: String!
   specId: String!
   stateRoot: String!
   extrinsicsRoot: String!
-  extrinsics: [Extrinsic!]!
-    @derivedFrom(field: "block")
-    @cardinality(value: 1000)
+  extrinsics: [Extrinsic!]! @derivedFrom(field: "block") @cardinality(value: 1000)
   events: [Event!]! @derivedFrom(field: "block") @cardinality(value: 1000)
-  rewards: [RewardEvent!]!
-    @derivedFrom(field: "block")
-    @cardinality(value: 1000)
+  rewards: [RewardEvent!]! @derivedFrom(field: "block") @cardinality(value: 1000)
   calls: [Call!]! @derivedFrom(field: "block") @cardinality(value: 1000)
   logs: [Log!]! @derivedFrom(field: "block") @cardinality(value: 1000)
   spacePledged: BigInt!
   blockchainSize: BigInt!
   extrinsicsCount: Int!
   eventsCount: Int!
-  author: Account
+  author: Account @index
 }
 
 type ExtrinsicModuleName @entity {
@@ -45,12 +37,12 @@ type ExtrinsicModuleName @entity {
 
 type Extrinsic @entity {
   id: ID! @index
-  hash: String!
+  hash: String! @index
   indexInBlock: Int!
   nonce: BigInt
   name: String!
-  signer: Account
-  signature: String @index
+  signer: Account @index
+  signature: String
   error: JSON
   tip: BigInt
   fee: BigInt
@@ -70,7 +62,7 @@ type EventModuleName @entity {
 
 type Event @entity {
   id: ID! @index
-  indexInBlock: Int! @index
+  indexInBlock: Int!
   name: String!
   timestamp: DateTime! @index
   phase: String!
@@ -91,7 +83,7 @@ type RewardEvent @entity {
   block: Block
   extrinsic: Extrinsic
   call: Call
-  account: Account
+  account: Account @index
   amount: BigInt
 }
 
@@ -111,6 +103,7 @@ type Call @entity {
 }
 
 type Log @entity {
+  id: ID! @index
   kind: String! @index
   value: JSON
   block: Block!
@@ -128,25 +121,23 @@ type Operator @entity {
   currentTotalStake: BigInt
   currentEpochRewards: BigInt
   totalShares: BigInt
-  nominatorAmount: Int! @index
-  nominators: [Nominator!]!
-    @derivedFrom(field: "operator")
-    @cardinality(value: 1000)
+  nominatorAmount: Int!
+  nominators: [Nominator!]! @derivedFrom(field: "operator") @cardinality(value: 1000)
   status: String
-  updatedAt: BigInt @index
+  updatedAt: BigInt
 }
 
 type Nominator @entity {
   id: ID! @index
-  operator: Operator!
-  account: Account!
+  operator: Operator! @index
+  account: Account! @index
   shares: BigInt
   updatedAt: BigInt
 }
 
 type AccountRewards @entity {
   id: ID! @index
-  account: Account!
+  account: Account! @index
   amount: BigInt
   block: BigInt @index
   vote: BigInt @index


### PR DESCRIPTION
### **User description**
Changes to Graphql schema:
- Indexed key fields for efficient lookups
- Cardinality hints for relationship optimization
- Indexes on timestamp fields for time-based queries
- Indexes on account and operator fields for common blockchain explorer queries


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added indexes to key fields such as `id`, `hash`, `timestamp`, `account`, and `operator` to improve database lookup efficiency.
- Consolidated `@derivedFrom` and `@cardinality` annotations on single lines for better readability.
- Enhanced indexing on timestamp fields to optimize time-based queries.
- Improved indexing on account and operator fields to support common blockchain explorer queries.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schema.graphql</strong><dd><code>Improve database indexing and optimize GraphQL schema</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

indexers/squid-blockexplorer/schema.graphql

<li>Added indexes to multiple fields for efficient lookups.<br> <li> Consolidated <code>@derivedFrom</code> and <code>@cardinality</code> annotations on single <br>lines.<br> <li> Added <code>@index</code> to timestamp fields for time-based queries.<br> <li> Added <code>@index</code> to account and operator fields for common blockchain <br>explorer queries.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/751/files#diff-93b506a298c74c0e346ef0a991abd97f4a7a319d5804dd5f92dd3b897d84dc63">+19/-28</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

