### PR TITLE
Add the amount pending next to each nominator when on rpc

### DIFF
--- a/explorer/src/components/Staking/OperatorNominatorTable.tsx
+++ b/explorer/src/components/Staking/OperatorNominatorTable.tsx
@@ -11,6 +11,7 @@ import {
 import useDomains from 'hooks/useDomains'
 import useMediaQuery from 'hooks/useMediaQuery'
 import { useSquidQuery } from 'hooks/useSquidQuery'
+import useWallet from 'hooks/useWallet'
 import { useWindowFocus } from 'hooks/useWindowFocus'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
@@ -20,7 +21,7 @@ import { useConsensusStates } from 'states/consensus'
 import { hasValue, useQueryStates } from 'states/query'
 import { useViewStates } from 'states/view'
 import type { Cell } from 'types/table'
-import { limitNumberDecimals, numberWithCommas } from 'utils/number'
+import { bigNumberToNumber, limitNumberDecimals, numberWithCommas } from 'utils/number'
 import { sort } from 'utils/sort'
 import { shortString } from 'utils/string'
 import { countTablePages } from 'utils/table'
@@ -33,6 +34,7 @@ type Props = {
 
 export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
   const { ref, inView } = useInView()
+  const { subspaceAccount } = useWallet()
   const { operatorId } = useParams<{ operatorId?: string }>()
   const inFocus = useWindowFocus()
   const { selectedChain } = useDomains()
@@ -43,11 +45,16 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
     pageIndex: 0,
   })
   const { useRpcData } = useViewStates()
-  const { deposits } = useConsensusStates()
+  const { operators: rpcOperators, deposits } = useConsensusStates()
+
+  const op = useMemo(
+    () => rpcOperators.find((o) => o.id.toString() === operatorId),
+    [operatorId, rpcOperators],
+  )
 
   const columns = useMemo(() => {
     if (!operator || operator.totalShares == 0) return []
-    return [
+    const cols = [
       {
         accessorKey: 'account',
         header: 'Account Id',
@@ -77,22 +84,24 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
         header: 'Stakes',
         cell: ({
           row,
-        }: Cell<OperatorNominatorsByIdQuery['nominatorsConnection']['edges'][0]['node']>) => (
-          <div>
-            {numberWithCommas(
-              limitNumberDecimals(
-                Number(
+        }: Cell<OperatorNominatorsByIdQuery['nominatorsConnection']['edges'][0]['node']>) => {
+          return (
+            <div>
+              {numberWithCommas(
+                limitNumberDecimals(
                   Number(
-                    (BigInt(operator.currentTotalStake) / BigInt(operator.totalShares)) *
-                      BigInt(row.original.shares),
-                  ) /
-                    10 ** 18,
+                    Number(
+                      (BigInt(operator.currentTotalStake) / BigInt(operator.totalShares)) *
+                        BigInt(row.original.shares),
+                    ) /
+                      10 ** 18,
+                  ),
                 ),
-              ),
-            )}{' '}
-            {selectedChain.token.symbol}
-          </div>
-        ),
+              )}{' '}
+              {selectedChain.token.symbol}
+            </div>
+          )
+        },
       },
       {
         accessorKey: 'shares',
@@ -124,7 +133,50 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
           operator.operatorOwner === row.original.account.id ? 'Yes' : 'No',
       },
     ]
-  }, [isLargeLaptop, operator, selectedChain.token.symbol, selectedChain.urls.page])
+    if (
+      useRpcData &&
+      deposits.find((d) => d.account === subspaceAccount && d.operatorId.toString() === operatorId)
+    )
+      cols.push({
+        accessorKey: 'myStake',
+        header: 'My Stake',
+        cell: ({
+          row,
+        }: Cell<OperatorNominatorsByIdQuery['nominatorsConnection']['edges'][0]['node']>) => {
+          const deposit = deposits.find(
+            (d) => d.account === row.original.account.id && d.operatorId.toString() === operatorId,
+          )
+          const sharesValue =
+            op && BigInt(op.currentTotalShares) > BigInt(0)
+              ? (BigInt(op.currentTotalStake) * BigInt(1000)) / BigInt(op.currentTotalShares)
+              : BigInt(0)
+          return (
+            <div>
+              {deposit && deposit.shares !== '0' && (
+                <>
+                  {`Staked: ${bigNumberToNumber(((BigInt(deposit.shares) * BigInt(sharesValue)) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
+                  <br />
+                </>
+              )}
+              {deposit &&
+                deposit.pending.amount !== '0' &&
+                `Pending: ${bigNumberToNumber((BigInt(deposit.pending.amount) + BigInt(deposit.pending.storageFeeDeposit)).toString())} ${selectedChain.token.symbol}`}
+            </div>
+          )
+        },
+      })
+    return cols
+  }, [
+    deposits,
+    isLargeLaptop,
+    op,
+    operator,
+    operatorId,
+    selectedChain.token.symbol,
+    selectedChain.urls.page,
+    subspaceAccount,
+    useRpcData,
+  ])
 
   const orderBy = useMemo(
     () => sort(sorting, NominatorOrderByInput.IdAsc) as NominatorOrderByInput,

--- a/explorer/src/components/Staking/OperatorNominatorTable.tsx
+++ b/explorer/src/components/Staking/OperatorNominatorTable.tsx
@@ -253,7 +253,7 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
       <SortedTable
         data={nominators}
         columns={columns}
-        showNavigation={true}
+        showNavigation={!useRpcData}
         sorting={sorting}
         onSortingChange={setSorting}
         pagination={pagination}

--- a/explorer/src/components/Staking/OperatorsList.tsx
+++ b/explorer/src/components/Staking/OperatorsList.tsx
@@ -189,6 +189,50 @@ export const OperatorsList: FC = () => {
           <div>{`${bigNumberToNumber(row.original.currentTotalStake)} ${selectedChain.token.symbol}`}</div>
         ),
       },
+    ]
+    if (useRpcData && deposits.find((d) => d.account === subspaceAccount))
+      cols.push({
+        accessorKey: 'deposits',
+        header: 'Deposits',
+        enableSorting: !useRpcData,
+        cell: ({
+          row,
+        }: Cell<
+          OperatorsConnectionQuery['operatorsConnection']['edges'][0]['node'] | Operators
+        >) => {
+          const opDeposits = deposits.filter((d) => d.operatorId.toString() === row.original.id)
+          const depositShares = opDeposits.reduce(
+            (acc, deposit) => acc + BigInt(deposit.shares),
+            BigInt(0),
+          )
+          const pendingAmount = opDeposits.reduce(
+            (acc, deposit) => acc + BigInt(deposit.pending.amount),
+            BigInt(0),
+          )
+          const pendingStorageFee = opDeposits.reduce(
+            (acc, deposit) => acc + BigInt(deposit.pending.storageFeeDeposit),
+            BigInt(0),
+          )
+          const op = rpcOperators.find((o) => o.id === row.original.id)
+          const sharesValue =
+            op && BigInt(op.currentTotalShares) > BigInt(0)
+              ? (BigInt(op.currentTotalStake) * BigInt(1000)) / BigInt(op.currentTotalShares)
+              : BigInt(0)
+          return (
+            <div>
+              {depositShares > BigInt(0) && (
+                <>
+                  {`Staked: ${bigNumberToNumber(((BigInt(depositShares) * BigInt(sharesValue)) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
+                  <br />
+                </>
+              )}
+              {pendingAmount > BigInt(0) &&
+                `Pending; ${bigNumberToNumber((BigInt(pendingAmount) + BigInt(pendingStorageFee)).toString())} ${selectedChain.token.symbol}`}
+            </div>
+          )
+        },
+      })
+    cols.push(
       {
         accessorKey: 'nominators',
         header: 'Nominators',
@@ -230,7 +274,7 @@ export const OperatorsList: FC = () => {
           </div>
         ),
       },
-    ]
+    )
     if (useRpcData && deposits.find((d) => d.account === subspaceAccount))
       cols.push({
         accessorKey: 'myStake',

--- a/explorer/src/components/Staking/OperatorsList.tsx
+++ b/explorer/src/components/Staking/OperatorsList.tsx
@@ -222,12 +222,12 @@ export const OperatorsList: FC = () => {
             <div>
               {depositShares > BigInt(0) && (
                 <>
-                  {`Staked: ${bigNumberToNumber(((BigInt(depositShares) * BigInt(sharesValue)) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
+                  {`Staked: ${bigNumberToNumber(((depositShares * sharesValue) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
                   <br />
                 </>
               )}
               {pendingAmount > BigInt(0) &&
-                `Pending; ${bigNumberToNumber((BigInt(pendingAmount) + BigInt(pendingStorageFee)).toString())} ${selectedChain.token.symbol}`}
+                `Pending; ${bigNumberToNumber((pendingAmount + pendingStorageFee).toString())} ${selectedChain.token.symbol}`}
             </div>
           )
         },
@@ -297,7 +297,7 @@ export const OperatorsList: FC = () => {
             <div>
               {deposit && deposit.shares !== '0' && (
                 <>
-                  {`Staked: ${bigNumberToNumber(((BigInt(deposit.shares) * BigInt(sharesValue)) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
+                  {`Staked: ${bigNumberToNumber(((BigInt(deposit.shares) * sharesValue) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
                   <br />
                 </>
               )}

--- a/explorer/src/utils/chainStateParsing.ts
+++ b/explorer/src/utils/chainStateParsing.ts
@@ -1,0 +1,53 @@
+import type { StorageKey } from '@polkadot/types'
+import type { AnyTuple, Codec } from '@polkadot/types-codec/types'
+import { Deposit, Operators, RawDeposit, Withdrawal } from 'types/consensus'
+
+export const formatOperators = (
+  operators: [StorageKey<AnyTuple>, Codec][],
+  operatorIdOwner: [StorageKey<AnyTuple>, Codec][],
+) =>
+  operators.map((operator, key) => {
+    const op = operator[1].toJSON() as Omit<Operators, 'id' | 'operatorOwner'>
+    return {
+      id: (operator[0].toHuman() as string[])[0],
+      operatorOwner: operatorIdOwner[key][1].toJSON() as string,
+      ...op,
+      minimumNominatorStake: BigInt(op.minimumNominatorStake).toString(10),
+      currentTotalStake: BigInt(op.currentTotalStake).toString(10),
+      currentTotalShares: BigInt(op.currentTotalShares).toString(10),
+      totalStorageFeeDeposit: BigInt(op.totalStorageFeeDeposit).toString(10),
+      status: JSON.stringify(op.status),
+    } as Operators
+  })
+
+export const formatDeposits = (deposits: [StorageKey<AnyTuple>, Codec][]) =>
+  deposits.map((deposit) => {
+    const parsedDeposit = deposit[1].toJSON() as RawDeposit
+    return {
+      operatorId: parseInt((deposit[0].toHuman() as string[])[0]),
+      account: (deposit[0].toHuman() as string[])[1],
+      shares: parseInt(parsedDeposit.known.shares.toString(), 16).toString(),
+      storageFeeDeposit: parseInt(parsedDeposit.known.storageFeeDeposit.toString(), 16).toString(),
+      pending: {
+        amount: BigInt(parsedDeposit.pending.amount).toString(10),
+        storageFeeDeposit: BigInt(parsedDeposit.pending.storageFeeDeposit).toString(10),
+      },
+    } as Deposit
+  })
+
+export const formatWithdrawals = (withdrawals: [StorageKey<AnyTuple>, Codec][]) =>
+  withdrawals.map((withdrawal) => {
+    const parsedWithdrawal = withdrawal[1].toJSON() as Omit<Withdrawal, 'operatorId'>
+    return {
+      operatorId: parseInt((withdrawal[0].toHuman() as string[])[0]),
+      totalWithdrawalAmount: parsedWithdrawal.totalWithdrawalAmount,
+      withdrawals: parsedWithdrawal.withdrawals,
+      withdrawalInShares: {
+        domainEpoch: parsedWithdrawal.withdrawalInShares.domainEpoch,
+        unlockAtConfirmedDomainBlockNumber:
+          parsedWithdrawal.withdrawalInShares.unlockAtConfirmedDomainBlockNumber,
+        shares: BigInt(parsedWithdrawal.withdrawalInShares.shares).toString(10),
+        storageFeeRefund: BigInt(parsedWithdrawal.withdrawalInShares.storageFeeRefund).toString(10),
+      },
+    } as Withdrawal
+  })

--- a/explorer/src/utils/chainStateParsing.ts
+++ b/explorer/src/utils/chainStateParsing.ts
@@ -26,7 +26,7 @@ export const formatDeposits = (deposits: [StorageKey<AnyTuple>, Codec][]) =>
     return {
       operatorId: parseInt((deposit[0].toHuman() as string[])[0]),
       account: (deposit[0].toHuman() as string[])[1],
-      shares: parseInt(parsedDeposit.known.shares.toString(), 16).toString(),
+      shares: BigInt(parsedDeposit.known.shares).toString(10),
       storageFeeDeposit: parseInt(parsedDeposit.known.storageFeeDeposit.toString(), 16).toString(),
       pending: {
         amount: BigInt(parsedDeposit.pending.amount).toString(10),


### PR DESCRIPTION
### **User description**
## Add the amount pending next to each nominator when on rpc

See how much an operator has pending deposit or deposited and what you have pending

### Screenshot

![OperatorsList](https://github.com/user-attachments/assets/1a0ccbd6-9323-4edc-aef9-c262e466ba8d)
![OperatorDetails](https://github.com/user-attachments/assets/4002625c-b490-4e15-b681-689708efb8f1)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added logic to display pending and staked amounts for nominators in `OperatorNominatorTable`.
- Introduced new columns in `OperatorsList` to show deposits and stakes.
- Refactored `useConsensusData` to use new utility functions for data formatting.
- Added utility functions in `chainStateParsing.ts` for formatting operators, deposits, and withdrawals.
- Improved error handling and data parsing across components.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OperatorNominatorTable.tsx</strong><dd><code>Display pending and staked amounts for nominators in table</code></dd></summary>
<hr>

explorer/src/components/Staking/OperatorNominatorTable.tsx

<li>Added logic to display pending and staked amounts for nominators.<br> <li> Introduced <code>useWallet</code> hook to get subspace account.<br> <li> Modified table columns to include "My Stake" when using RPC data.<br> <li> Adjusted table navigation based on RPC data usage.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/755/files#diff-1cc906aaa845e6e8da1214d968027b78682f0313071a2fa206797b4a8ae1defe">+71/-19</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OperatorsList.tsx</strong><dd><code>Show deposits and stakes for operators in list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/Staking/OperatorsList.tsx

<li>Added logic to display deposits and stakes for operators.<br> <li> Introduced "My Stake" column when using RPC data.<br> <li> Adjusted sorting and filtering logic based on RPC data.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/755/files#diff-2f63461d6975c034ac8b70b9ccf2030ca14290ecc622680b0d37d6ad4cd04711">+101/-11</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useConsensusData.ts</strong><dd><code>Refactor consensus data handling and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/hooks/useConsensusData.ts

<li>Refactored to use <code>formatDeposits</code>, <code>formatOperators</code>, and <br><code>formatWithdrawals</code> utility functions.<br> <li> Improved error handling and data formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/755/files#diff-734fc7f643a5c569f33bad078492efc35cb5f716856b646e59a933a1f322c886">+15/-46</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chainStateParsing.ts</strong><dd><code>Add utility functions for chain state parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/utils/chainStateParsing.ts

<li>Added utility functions to format operators, deposits, and <br>withdrawals.<br> <li> Improved data parsing and conversion logic.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/755/files#diff-19fbe49b66c9235cb2ba33f888f954ecb7c683301696d4f55d29b3efd863713a">+53/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

