### PR TITLE
Display withdrawals on staking when on rpc

### DIFF
--- a/explorer/src/components/Staking/OperatorNominatorTable.tsx
+++ b/explorer/src/components/Staking/OperatorNominatorTable.tsx
@@ -152,14 +152,15 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
               : BigInt(0)
           return (
             <div>
-              {deposit && deposit.shares !== '0' && (
+              {deposit && deposit.shares > BigInt(0) && (
                 <>
                   {`Staked: ${bigNumberToNumber(((BigInt(deposit.shares) * BigInt(sharesValue)) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
                   <br />
                 </>
               )}
               {deposit &&
-                deposit.pending.amount !== '0' &&
+                deposit.pending !== null &&
+                deposit.pending.amount > BigInt(0) &&
                 `Pending: ${bigNumberToNumber((BigInt(deposit.pending.amount) + BigInt(deposit.pending.storageFeeDeposit)).toString())} ${selectedChain.token.symbol}`}
             </div>
           )

--- a/explorer/src/components/Staking/OperatorNominatorTable.tsx
+++ b/explorer/src/components/Staking/OperatorNominatorTable.tsx
@@ -1,6 +1,6 @@
 import { SortingState } from '@tanstack/react-table'
 import { SortedTable } from 'components/common/SortedTable'
-import { PAGE_SIZE } from 'constants/general'
+import { BIGINT_ZERO, PAGE_SIZE, SHARES_CALCULATION_MULTIPLIER } from 'constants/general'
 import { INTERNAL_ROUTES, Routes } from 'constants/routes'
 import {
   NominatorOrderByInput,
@@ -147,21 +147,22 @@ export const OperatorNominatorTable: FC<Props> = ({ operator }) => {
             (d) => d.account === row.original.account.id && d.operatorId.toString() === operatorId,
           )
           const sharesValue =
-            op && BigInt(op.currentTotalShares) > BigInt(0)
-              ? (BigInt(op.currentTotalStake) * BigInt(1000)) / BigInt(op.currentTotalShares)
-              : BigInt(0)
+            op && BigInt(op.currentTotalShares) > BIGINT_ZERO
+              ? (BigInt(op.currentTotalStake) * SHARES_CALCULATION_MULTIPLIER) /
+                BigInt(op.currentTotalShares)
+              : BIGINT_ZERO
           return (
             <div>
-              {deposit && deposit.shares > BigInt(0) && (
+              {deposit && deposit.shares > BIGINT_ZERO && (
                 <>
-                  {`Staked: ${bigNumberToNumber(((BigInt(deposit.shares) * BigInt(sharesValue)) / BigInt(1000)).toString())} ${selectedChain.token.symbol}`}
+                  {`Staked: ${bigNumberToNumber((deposit.shares * sharesValue) / SHARES_CALCULATION_MULTIPLIER)} ${selectedChain.token.symbol}`}
                   <br />
                 </>
               )}
               {deposit &&
                 deposit.pending !== null &&
-                deposit.pending.amount > BigInt(0) &&
-                `Pending: ${bigNumberToNumber((BigInt(deposit.pending.amount) + BigInt(deposit.pending.storageFeeDeposit)).toString())} ${selectedChain.token.symbol}`}
+                deposit.pending.amount > BIGINT_ZERO &&
+                `Pending: ${bigNumberToNumber(deposit.pending.amount + deposit.pending.storageFeeDeposit)} ${selectedChain.token.symbol}`}
             </div>
           )
         },

--- a/explorer/src/components/Staking/OperatorsList.tsx
+++ b/explorer/src/components/Staking/OperatorsList.tsx
@@ -61,7 +61,7 @@ export const OperatorsList: FC = () => {
   const { loadData: loadConsensusData } = useConsensusData()
   const inFocus = useWindowFocus()
   const { useRpcData, myPositionOnly } = useViewStates()
-  console.log('withdrawals', withdrawals)
+
   useEffect(() => {
     loadDomainsData()
     loadConsensusData()

--- a/explorer/src/constants/general.ts
+++ b/explorer/src/constants/general.ts
@@ -40,3 +40,5 @@ export const searchTypes: SearchType[] = [
 ]
 
 export const SUBSPACE_ACC_PREFIX = 2254
+
+export const SHARES_CALCULATION_MULTIPLIER = BigInt(1000000000000)

--- a/explorer/src/constants/general.ts
+++ b/explorer/src/constants/general.ts
@@ -41,4 +41,6 @@ export const searchTypes: SearchType[] = [
 
 export const SUBSPACE_ACC_PREFIX = 2254
 
+export const BIGINT_ZERO = BigInt(0)
+
 export const SHARES_CALCULATION_MULTIPLIER = BigInt(1000000000000)

--- a/explorer/src/states/consensus.ts
+++ b/explorer/src/states/consensus.ts
@@ -11,6 +11,7 @@ import {
   SuccessfulBundle,
   Withdrawal,
 } from 'types/consensus'
+import { bigIntDeserializer, bigIntSerializer } from 'utils/number'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
@@ -118,7 +119,10 @@ export const useConsensusStates = create<ConsensusState>()(
     }),
     {
       name: 'consensus-storage',
+      version: 2,
       storage: createJSONStorage(() => localStorage),
+      serialize: (state) => JSON.stringify(state, bigIntSerializer),
+      deserialize: (str) => JSON.parse(str, bigIntDeserializer),
     },
   ),
 )

--- a/explorer/src/states/domains.ts
+++ b/explorer/src/states/domains.ts
@@ -1,4 +1,5 @@
 import type { Domain } from 'types/domain'
+import { bigIntDeserializer, bigIntSerializer } from 'utils/number'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
@@ -28,8 +29,10 @@ export const useDomainsStates = create<DomainsState>()(
     }),
     {
       name: 'domains-storage',
-      version: 2,
+      version: 3,
       storage: createJSONStorage(() => localStorage),
+      serialize: (state) => JSON.stringify(state, bigIntSerializer),
+      deserialize: (str) => JSON.parse(str, bigIntDeserializer),
     },
   ),
 )

--- a/explorer/src/states/transactions.ts
+++ b/explorer/src/states/transactions.ts
@@ -1,5 +1,6 @@
 import { TransactionStatus } from 'constants/transaction'
 import type { Transaction, TransactionWithMetadata } from 'types/transaction'
+import { bigIntDeserializer, bigIntSerializer } from 'utils/number'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
@@ -35,9 +36,9 @@ export const useTransactionsStates = create<TransactionsState>()(
         })),
       getNextNonceForAccount: (address: string) => {
         const lastNonce = get()
-          .pendingTransactions.filter(t => t.ownerAccount.address === address)
-          .reduce((maxNonce, tx) => Math.max(maxNonce, tx.nonce), -1);
-        return lastNonce + 1;
+          .pendingTransactions.filter((t) => t.ownerAccount.address === address)
+          .reduce((maxNonce, tx) => Math.max(maxNonce, tx.nonce), -1)
+        return lastNonce + 1
       },
       removePendingTransactions: (transaction: Transaction) =>
         set((state) => ({
@@ -78,7 +79,10 @@ export const useTransactionsStates = create<TransactionsState>()(
     }),
     {
       name: 'transactions-storage',
+      version: 2,
       storage: createJSONStorage(() => localStorage),
+      serialize: (state) => JSON.stringify(state, bigIntSerializer),
+      deserialize: (str) => JSON.parse(str, bigIntDeserializer),
     },
   ),
 )

--- a/explorer/src/states/view.ts
+++ b/explorer/src/states/view.ts
@@ -1,3 +1,4 @@
+import { bigIntDeserializer, bigIntSerializer } from 'utils/number'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
@@ -27,8 +28,10 @@ export const useViewStates = create<ViewStatesAndFn>()(
     }),
     {
       name: 'view-storage',
-      version: 1,
+      version: 2,
       storage: createJSONStorage(() => localStorage),
+      serialize: (state) => JSON.stringify(state, bigIntSerializer),
+      deserialize: (str) => JSON.parse(str, bigIntDeserializer),
     },
   ),
 )

--- a/explorer/src/types/consensus.ts
+++ b/explorer/src/types/consensus.ts
@@ -125,6 +125,7 @@ export type Deposit = {
 
 export type Withdrawal = {
   operatorId: number
+  account: string
   totalWithdrawalAmount: number
   withdrawals: string[]
   withdrawalInShares: {

--- a/explorer/src/types/consensus.ts
+++ b/explorer/src/types/consensus.ts
@@ -106,32 +106,49 @@ export type RawDeposit = {
     storageFeeDeposit: number
   }
   pending: {
-    effectiveDomainEpoch: number[]
+    effectiveDomainEpoch: [number, number]
     amount: string
     storageFeeDeposit: string
-  }
+  } | null
 }
 
 export type Deposit = {
   operatorId: number
   account: string
-  shares: string
-  storageFeeDeposit: string
-  pending: {
-    amount: string
-    storageFeeDeposit: string
+  shares: bigint
+  storageFeeDeposit: bigint
+  known: {
+    shares: bigint
+    storageFeeDeposit: bigint
   }
+  pending: {
+    effectiveDomainId: number
+    effectiveDomainEpoch: number
+    amount: bigint
+    storageFeeDeposit: bigint
+  } | null
 }
 
-export type Withdrawal = {
-  operatorId: number
-  account: string
-  totalWithdrawalAmount: number
+export type RawWithdrawal = {
+  totalWithdrawalAmount: string
   withdrawals: string[]
   withdrawalInShares: {
     domainEpoch: number[]
     unlockAtConfirmedDomainBlockNumber: number
     shares: string
     storageFeeRefund: string
+  }
+}
+
+export type Withdrawal = {
+  operatorId: number
+  account: string
+  totalWithdrawalAmount: bigint
+  withdrawals: string[]
+  withdrawalInShares: {
+    domainEpoch: number[]
+    unlockAtConfirmedDomainBlockNumber: number
+    shares: bigint
+    storageFeeRefund: bigint
   }
 }

--- a/explorer/src/utils/chainStateParsing.ts
+++ b/explorer/src/utils/chainStateParsing.ts
@@ -22,12 +22,13 @@ export const formatOperators = (
 
 export const formatDeposits = (deposits: [StorageKey<AnyTuple>, Codec][]) =>
   deposits.map((deposit) => {
+    const depositHeader = deposit[0].toHuman() as [string, string]
     const parsedDeposit = deposit[1].toJSON() as RawDeposit
     return {
-      operatorId: parseInt((deposit[0].toHuman() as string[])[0]),
-      account: (deposit[0].toHuman() as string[])[1],
-      shares: parseInt(parsedDeposit.known.shares.toString(), 16).toString(),
-      storageFeeDeposit: parseInt(parsedDeposit.known.storageFeeDeposit.toString(), 16).toString(),
+      operatorId: parseInt(depositHeader[0]),
+      account: depositHeader[1],
+      shares: BigInt(parsedDeposit.known.shares.toString()).toString(10),
+      storageFeeDeposit: BigInt(parsedDeposit.known.storageFeeDeposit.toString()).toString(10),
       pending: {
         amount: BigInt(parsedDeposit.pending.amount).toString(10),
         storageFeeDeposit: BigInt(parsedDeposit.pending.storageFeeDeposit).toString(10),
@@ -37,9 +38,11 @@ export const formatDeposits = (deposits: [StorageKey<AnyTuple>, Codec][]) =>
 
 export const formatWithdrawals = (withdrawals: [StorageKey<AnyTuple>, Codec][]) =>
   withdrawals.map((withdrawal) => {
+    const withdrawalHeader = withdrawal[0].toHuman() as [string, string]
     const parsedWithdrawal = withdrawal[1].toJSON() as Omit<Withdrawal, 'operatorId'>
     return {
-      operatorId: parseInt((withdrawal[0].toHuman() as string[])[0]),
+      operatorId: parseInt(withdrawalHeader[0]),
+      account: withdrawalHeader[1],
       totalWithdrawalAmount: parsedWithdrawal.totalWithdrawalAmount,
       withdrawals: parsedWithdrawal.withdrawals,
       withdrawalInShares: {

--- a/explorer/src/utils/chainStateParsing.ts
+++ b/explorer/src/utils/chainStateParsing.ts
@@ -1,6 +1,6 @@
 import type { StorageKey } from '@polkadot/types'
 import type { AnyTuple, Codec } from '@polkadot/types-codec/types'
-import { Deposit, Operators, RawDeposit, Withdrawal } from 'types/consensus'
+import { Deposit, Operators, RawDeposit, RawWithdrawal, Withdrawal } from 'types/consensus'
 
 export const formatOperators = (
   operators: [StorageKey<AnyTuple>, Codec][],
@@ -16,7 +16,7 @@ export const formatOperators = (
       currentTotalStake: BigInt(op.currentTotalStake).toString(10),
       currentTotalShares: BigInt(op.currentTotalShares).toString(10),
       totalStorageFeeDeposit: BigInt(op.totalStorageFeeDeposit).toString(10),
-      status: JSON.stringify(op.status),
+      status: JSON.stringify(op.status.toString()),
     } as Operators
   })
 
@@ -24,33 +24,43 @@ export const formatDeposits = (deposits: [StorageKey<AnyTuple>, Codec][]) =>
   deposits.map((deposit) => {
     const depositHeader = deposit[0].toHuman() as [string, string]
     const parsedDeposit = deposit[1].toJSON() as RawDeposit
+    const pending =
+      parsedDeposit.pending !== null
+        ? {
+            effectiveDomainId: parsedDeposit.pending.effectiveDomainEpoch[0],
+            effectiveDomainEpoch: parsedDeposit.pending.effectiveDomainEpoch[1],
+            amount: BigInt(parsedDeposit.pending.amount),
+            storageFeeDeposit: BigInt(parsedDeposit.pending.storageFeeDeposit),
+          }
+        : null
     return {
       operatorId: parseInt(depositHeader[0]),
       account: depositHeader[1],
-      shares: BigInt(parsedDeposit.known.shares.toString()).toString(10),
-      storageFeeDeposit: BigInt(parsedDeposit.known.storageFeeDeposit.toString()).toString(10),
-      pending: {
-        amount: BigInt(parsedDeposit.pending.amount).toString(10),
-        storageFeeDeposit: BigInt(parsedDeposit.pending.storageFeeDeposit).toString(10),
+      shares: BigInt(parsedDeposit.known.shares.toString()),
+      storageFeeDeposit: BigInt(parsedDeposit.known.storageFeeDeposit.toString()),
+      known: {
+        shares: BigInt(0), // BigInt(parsedDeposit.known.shares.toString()),
+        storageFeeDeposit: BigInt(0), // BigInt(parsedDeposit.known.storageFeeDeposit.toString()),
       },
+      pending,
     } as Deposit
   })
 
 export const formatWithdrawals = (withdrawals: [StorageKey<AnyTuple>, Codec][]) =>
   withdrawals.map((withdrawal) => {
     const withdrawalHeader = withdrawal[0].toHuman() as [string, string]
-    const parsedWithdrawal = withdrawal[1].toJSON() as Omit<Withdrawal, 'operatorId'>
+    const parsedWithdrawal = withdrawal[1].toJSON() as RawWithdrawal
     return {
       operatorId: parseInt(withdrawalHeader[0]),
       account: withdrawalHeader[1],
-      totalWithdrawalAmount: parsedWithdrawal.totalWithdrawalAmount,
+      totalWithdrawalAmount: BigInt(parsedWithdrawal.totalWithdrawalAmount),
       withdrawals: parsedWithdrawal.withdrawals,
       withdrawalInShares: {
         domainEpoch: parsedWithdrawal.withdrawalInShares.domainEpoch,
         unlockAtConfirmedDomainBlockNumber:
           parsedWithdrawal.withdrawalInShares.unlockAtConfirmedDomainBlockNumber,
-        shares: BigInt(parsedWithdrawal.withdrawalInShares.shares).toString(10),
-        storageFeeRefund: BigInt(parsedWithdrawal.withdrawalInShares.storageFeeRefund).toString(10),
+        shares: BigInt(parsedWithdrawal.withdrawalInShares.shares),
+        storageFeeRefund: BigInt(parsedWithdrawal.withdrawalInShares.storageFeeRefund),
       },
     } as Withdrawal
   })

--- a/explorer/src/utils/chainStateParsing.ts
+++ b/explorer/src/utils/chainStateParsing.ts
@@ -39,8 +39,8 @@ export const formatDeposits = (deposits: [StorageKey<AnyTuple>, Codec][]) =>
       shares: BigInt(parsedDeposit.known.shares.toString()),
       storageFeeDeposit: BigInt(parsedDeposit.known.storageFeeDeposit.toString()),
       known: {
-        shares: BigInt(0), // BigInt(parsedDeposit.known.shares.toString()),
-        storageFeeDeposit: BigInt(0), // BigInt(parsedDeposit.known.storageFeeDeposit.toString()),
+        shares: BigInt(parsedDeposit.known.shares.toString()),
+        storageFeeDeposit: BigInt(parsedDeposit.known.storageFeeDeposit.toString()),
       },
       pending,
     } as Deposit

--- a/explorer/src/utils/number.ts
+++ b/explorer/src/utils/number.ts
@@ -99,3 +99,11 @@ export const numberPositionSuffix = (number: number) => {
   if (j === 3 && k !== 13) return number + 'rd'
   return number + 'th'
 }
+
+export const bigIntSerializer = (key: string, value: bigint | unknown): string | unknown =>
+  typeof value === 'bigint' ? value.toString() + 'n' : value
+
+export const bigIntDeserializer = (key: string, value: string | unknown): bigint | unknown =>
+  typeof value === 'string' && /^\d+n$/.test(value as string)
+    ? BigInt(value.toString().slice(0, -1))
+    : value

--- a/explorer/src/utils/number.ts
+++ b/explorer/src/utils/number.ts
@@ -24,7 +24,9 @@ export const formatUnits = (value: string): string => {
 export const floatToStringWithDecimals = (value: number, decimals = 4): string =>
   BigInt(value * 10 ** decimals).toString()
 
-export const bigNumberToNumber = (bigNumber: string, precision = 4): number => {
+export const bigNumberToNumber = (bigNumber: string | bigint, precision = 4): number => {
+  if (typeof bigNumber === 'bigint') bigNumber = bigNumber.toString()
+
   const number = formatUnits(bigNumber)
 
   return limitNumberDecimals(number, precision)


### PR DESCRIPTION
### **User description**
## Display withdrawals on staking when on rpc


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added handling and display of withdrawal data in the staking operators list.
- Introduced error handling for deposit parsing to prevent crashes.
- Enhanced the `Withdrawal` type by adding an `account` field.
- Improved parsing logic for deposits and withdrawals to handle new data structures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OperatorsList.tsx</strong><dd><code>Add and display withdrawal data in staking operators list</code></dd></summary>
<hr>

explorer/src/components/Staking/OperatorsList.tsx

<li>Added withdrawal data handling and display.<br> <li> Introduced error handling for deposit parsing.<br> <li> Enhanced table to show user-specific withdrawals.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/756/files#diff-2f63461d6975c034ac8b70b9ccf2030ca14290ecc622680b0d37d6ad4cd04711">+92/-34</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>consensus.ts</strong><dd><code>Extend Withdrawal type with account field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/types/consensus.ts

- Added `account` field to `Withdrawal` type.



</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/756/files#diff-e50d0c017ad68aed1dfe87e953f345c1d30af5efaf9ed0f2246e6b5feafcb88b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chainStateParsing.ts</strong><dd><code>Enhance chain state parsing for deposits and withdrawals</code>&nbsp; </dd></summary>
<hr>

explorer/src/utils/chainStateParsing.ts

<li>Improved parsing for deposits and withdrawals.<br> <li> Added handling for new <code>account</code> field in withdrawals.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/756/files#diff-19fbe49b66c9235cb2ba33f888f954ecb7c683301696d4f55d29b3efd863713a">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

