### PR TITLE
Add dev mode to wallet sidekick

### DIFF
--- a/explorer/src/components/WalletSideKick/AccountHeader.tsx
+++ b/explorer/src/components/WalletSideKick/AccountHeader.tsx
@@ -23,7 +23,7 @@ export const AccountHeader: FC<AccountHeaderProps> = ({ walletBalance, tokenSymb
           type='text'
           value={subspaceAccount ?? actingAccount.address}
           readOnly
-          className='border-purpleAccent dark:bg-blueAccent block w-[200px] rounded-xl bg-transparent px-4 text-sm text-gray-900 shadow-lg dark:text-white'
+          className='block w-[200px] rounded-xl border-purpleAccent bg-transparent px-4 text-sm text-gray-900 shadow-lg dark:bg-blueAccent dark:text-white'
         />
         <div className='ml-2'>
           <Tooltip text='Copy wallet address'>

--- a/explorer/src/components/WalletSideKick/AccountSummary.tsx
+++ b/explorer/src/components/WalletSideKick/AccountSummary.tsx
@@ -1,5 +1,5 @@
 import { shortString } from '@/utils/string'
-import { BookOpenIcon } from '@heroicons/react/24/outline'
+import { BookOpenIcon, WrenchIcon } from '@heroicons/react/24/outline'
 import { Accordion } from 'components/common/Accordion'
 import { Tooltip } from 'components/common/Tooltip'
 import type { Chain } from 'constants/chains'
@@ -8,6 +8,7 @@ import { AccountPreferenceSection } from 'constants/wallet'
 import Link from 'next/link'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
+import { usePreferencesStates } from 'states/preferences'
 import { limitNumberDecimals } from 'utils/number'
 import { AccountIcon } from '../common/AccountIcon'
 import { AccountBadge } from './AccountBadge'
@@ -32,6 +33,7 @@ export const AccountSummary: FC<AccountSummaryProps> = ({
   const { ref, inView } = useInView()
   const { topFarmers, topOperators, topNominators, setIsVisible } = useLeaderboard(subspaceAccount)
   const theme = useMemo(() => (selectedChain.isDomain ? 'ethereum' : 'beachball'), [selectedChain])
+  const { enableDevMode } = usePreferencesStates()
   const [preference, setPreference] = useState<AccountPreferenceSection>(
     AccountPreferenceSection.None,
   )
@@ -65,7 +67,12 @@ export const AccountSummary: FC<AccountSummaryProps> = ({
               <AccountIcon address={subspaceAccount} theme={theme} />
               <div className='relative'>
                 <span className='ml-2 hidden w-5 truncate text-lg font-medium text-grayDarker underline dark:text-white sm:block md:w-full'>
-                  {actingAccountName}
+                  {actingAccountName}{' '}
+                  {enableDevMode && (
+                    <span className='ml-2 rounded-full bg-purpleLighterAccent p-2 text-white'>
+                      <code>[Dev Mode]</code>
+                    </span>
+                  )}
                 </span>
                 <span className='ml-2 hidden w-5 truncate text-lg font-medium text-grayDarker underline dark:text-white sm:block md:w-full'>
                   {shortString(subspaceAccount)}
@@ -122,6 +129,14 @@ export const AccountSummary: FC<AccountSummaryProps> = ({
               className='m-2 flex cursor-default items-center justify-center rounded-full bg-purpleAccent p-2'
             >
               <BookOpenIcon className='w-8 text-white' />
+            </button>
+          </Tooltip>
+          <Tooltip text='Account settings'>
+            <button
+              onClick={() => onClick(AccountPreferenceSection.Settings)}
+              className='m-2 flex cursor-default items-center justify-center rounded-full bg-purpleAccent p-2'
+            >
+              <WrenchIcon className='w-8 text-white' />
             </button>
           </Tooltip>
         </div>

--- a/explorer/src/components/WalletSideKick/ActionsModal.tsx
+++ b/explorer/src/components/WalletSideKick/ActionsModal.tsx
@@ -22,6 +22,7 @@ import { QRCodeSVG } from 'qrcode.react'
 import { FC, Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useAddressBookStates } from 'states/addressBook'
+import { usePreferencesStates } from 'states/preferences'
 import { formatAddress } from 'utils//formatAddress'
 import { floatToStringWithDecimals, formatUnitsToNumber } from 'utils/number'
 import { camelToNormal, shortString } from 'utils/string'
@@ -41,11 +42,15 @@ type ActionsModalProps = {
   onClose: () => void
 }
 
-interface SendTokenFormValues {
+interface OptionalTxFormValues {
+  nonce?: number
+}
+
+interface SendTokenFormValues extends OptionalTxFormValues {
   receiver: string
   amount: number
 }
-interface MessageFormValues {
+interface MessageFormValues extends OptionalTxFormValues {
   message: string
 }
 
@@ -64,6 +69,7 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
   const [addressBookIsOpen, setAddressBookIsOpen] = useState<boolean>(false)
   const { sendAndSaveTx, handleTxError } = useTxHelper()
   const { addresses } = useAddressBookStates()
+  const { enableDevMode } = usePreferencesStates()
 
   const resetCategory = useCallback((extra?: () => void) => {
     setSelectedCategory(null)
@@ -79,16 +85,18 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
     () => ({
       receiver: '',
       amount: 0,
+      nonce: -1,
     }),
     [],
   )
   const initialMessageValues: MessageFormValues = useMemo(
     () => ({
       message: '',
+      nonce: -1,
     }),
     [],
   )
-  const initialCustomExtrinsicValues: CustomExtrinsicFormValues = useMemo(
+  const initialCustomExtrinsicValues: CustomExtrinsicFormValues & OptionalTxFormValues = useMemo(
     () =>
       selectedCategory &&
       selectedMethod &&
@@ -96,7 +104,7 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
       extrinsicsList[selectedCategory][selectedMethod].args
         ? Object.keys(extrinsicsList[selectedCategory][selectedMethod].args).reduce(
             (acc, key) => ({ ...acc, [key]: '' }),
-            {},
+            { nonce: -1 },
           )
         : {},
     [selectedCategory, selectedMethod, extrinsicsList],
@@ -116,12 +124,13 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
       selectedMethod &&
       extrinsicsList[selectedCategory][selectedMethod] &&
       extrinsicsList[selectedCategory][selectedMethod].args &&
-      Yup.object().shape(
-        Object.keys(extrinsicsList[selectedCategory][selectedMethod].args).reduce(
+      Yup.object().shape({
+        ...Object.keys(extrinsicsList[selectedCategory][selectedMethod].args).reduce(
           (acc, key) => ({ ...acc, [key]: Yup.string().required('This field is required') }),
           {},
         ),
-      ),
+        nonce: Yup.number().min(-1, 'Nonce must be greater or -1'),
+      }),
     [selectedCategory, selectedMethod, extrinsicsList],
   )
 
@@ -132,6 +141,7 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
           .min(0, `Amount  need to be greater than 0 ${tokenSymbol}`)
           .max(maxAmount, `Amount need to be less than ${maxAmount} ${tokenSymbol}`)
           .required('Amount to stake is required'),
+        nonce: Yup.number().min(-1, 'Nonce must be greater or -1'),
       }),
     [maxAmount, tokenSymbol],
   )
@@ -196,6 +206,7 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
           signer: injector.signer,
           to,
           amount,
+          nonce: values.nonce,
           error: setFormError,
         })
         if (hash) {
@@ -259,6 +270,7 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
           call: 'system.remark',
           tx,
           signer: injector.signer,
+          nonce: values.nonce,
           error: setFormError,
         })
         if (hash) {
@@ -293,6 +305,7 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
           call: `${selectedCategory}.${selectedMethod}`,
           tx,
           signer: injector.signer,
+          nonce: typeof values.nonce === 'string' ? parseInt(values.nonce) : values.nonce,
           error: setFormError,
         })
         if (hash) {
@@ -536,6 +549,37 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
                     ) : (
                       <div className='text-md mt-2 h-8' data-testid='placeHolder' />
                     )}
+                    {enableDevMode && (
+                      <>
+                        <span className='text-base font-medium text-grayDarker dark:text-white'>
+                          Nonce
+                        </span>
+                        <FieldArray
+                          name='dischargeNorms'
+                          render={() => (
+                            <div className={addressBookIsOpen ? 'relative z-10' : 'relative'}>
+                              <Field
+                                name='nonce'
+                                type='number'
+                                placeholder={`Nonce'
+                                }`}
+                                className={`mt-4 block w-[400px] rounded-xl bg-white px-4 py-[10px] text-sm text-gray-900 shadow-lg dark:bg-blueAccent dark:text-white ${
+                                  errors.nonce &&
+                                  'block w-full rounded-full bg-white px-4 py-[10px] text-sm text-gray-900 shadow-lg'
+                                }`}
+                              />
+                            </div>
+                          )}
+                        />
+                        {errors.nonce && touched.nonce ? (
+                          <div className='text-md mt-2 h-8 text-red-500' data-testid='errorMessage'>
+                            {errors.nonce}
+                          </div>
+                        ) : (
+                          <div className='text-md mt-2 h-8' data-testid='placeHolder' />
+                        )}
+                      </>
+                    )}
                     {ErrorPlaceholder}
                     {!actingAccount ? (
                       <div className='text-md mt-2 h-8 text-red-500' data-testid='errorMessage'>
@@ -631,6 +675,37 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
                       </div>
                     ) : (
                       <div className='text-md mt-2 h-8' data-testid='placeHolder' />
+                    )}
+                    {enableDevMode && action === WalletAction.SendRemark && (
+                      <>
+                        <span className='text-base font-medium text-grayDarker dark:text-white'>
+                          Nonce
+                        </span>
+                        <FieldArray
+                          name='dischargeNorms'
+                          render={() => (
+                            <div className={addressBookIsOpen ? 'relative z-10' : 'relative'}>
+                              <Field
+                                name='nonce'
+                                type='number'
+                                placeholder={`Nonce'
+                                }`}
+                                className={`mt-4 block w-[400px] rounded-xl bg-white px-4 py-[10px] text-sm text-gray-900 shadow-lg dark:bg-blueAccent dark:text-white ${
+                                  errors.nonce &&
+                                  'block w-full rounded-full bg-white px-4 py-[10px] text-sm text-gray-900 shadow-lg'
+                                }`}
+                              />
+                            </div>
+                          )}
+                        />
+                        {errors.nonce && touched.nonce ? (
+                          <div className='text-md mt-2 h-8 text-red-500' data-testid='errorMessage'>
+                            {errors.nonce}
+                          </div>
+                        ) : (
+                          <div className='text-md mt-2 h-8' data-testid='placeHolder' />
+                        )}
+                      </>
                     )}
                     {ErrorPlaceholder}
                     {!actingAccount ? (
@@ -742,6 +817,37 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
                         setSelectedValues={setFieldValue}
                       />
                     )}
+                    {enableDevMode && (
+                      <>
+                        <span className='text-base font-medium text-grayDarker dark:text-white'>
+                          Nonce
+                        </span>
+                        <FieldArray
+                          name='dischargeNorms'
+                          render={() => (
+                            <div className={addressBookIsOpen ? 'relative z-10' : 'relative'}>
+                              <Field
+                                name='nonce'
+                                type='number'
+                                placeholder={`Nonce'
+                                }`}
+                                className={`mt-4 block w-[400px] rounded-xl bg-white px-4 py-[10px] text-sm text-gray-900 shadow-lg dark:bg-blueAccent dark:text-white ${
+                                  errors.nonce &&
+                                  'block w-full rounded-full bg-white px-4 py-[10px] text-sm text-gray-900 shadow-lg'
+                                }`}
+                              />
+                            </div>
+                          )}
+                        />
+                        {errors.nonce && touched.nonce ? (
+                          <div className='text-md mt-2 h-8 text-red-500' data-testid='errorMessage'>
+                            {errors.nonce}
+                          </div>
+                        ) : (
+                          <div className='text-md mt-2 h-8' data-testid='placeHolder' />
+                        )}
+                      </>
+                    )}
                     {ErrorPlaceholder}
                     {!actingAccount && (
                       <div className='text-md mt-2 h-8 text-red-500' data-testid='errorMessage'>
@@ -783,6 +889,7 @@ export const ActionsModal: FC<ActionsModalProps> = ({ isOpen, action, onClose })
     handleCopy,
     handleSendToken,
     maxAmount,
+    enableDevMode,
     ErrorPlaceholder,
     accounts,
     addresses,

--- a/explorer/src/constants/wallet.ts
+++ b/explorer/src/constants/wallet.ts
@@ -37,4 +37,5 @@ export enum SupportedWalletExtension {
 export enum AccountPreferenceSection {
   None = 'None',
   AddressBook = 'addressBook',
+  Settings = 'settings',
 }

--- a/explorer/src/states/preferences.ts
+++ b/explorer/src/states/preferences.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+interface PreferencesDefaultState {
+  enableDevMode: boolean
+}
+
+interface PreferencesState extends PreferencesDefaultState {
+  switchDevMode: () => void
+  clear: () => void
+}
+
+const initialState: PreferencesDefaultState = {
+  enableDevMode: false,
+}
+
+export const usePreferencesStates = create<PreferencesState>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      switchDevMode: () =>
+        set((state) => ({
+          enableDevMode: !state.enableDevMode,
+        })),
+      clear: () => set(() => ({ ...initialState })),
+    }),
+    {
+      name: 'preferences-storage',
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+)


### PR DESCRIPTION
### **User description**
## Add dev mode to wallet sidekick

- Add account settings with dev mode to wallet sidekick
- Allow to override nonce when dev mode is 

### Screenshots

![Account Summary](https://github.com/user-attachments/assets/88fd76b5-3958-42d8-861f-0275446b089e)
![AccountSettings](https://github.com/user-attachments/assets/379b8072-fdcb-4840-98c2-4ea9ba56d164)
![SendTo](https://github.com/user-attachments/assets/2e97ba79-9c25-44e2-813e-c0c80162ab6f)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a dev mode toggle in account settings within the Wallet Sidekick.
- Implemented form validation and submission handling for the new dev mode settings.
- Displayed a dev mode indicator in the account summary when dev mode is enabled.
- Included a settings button in the account summary for easy access.
- Added a nonce field for dev mode in various forms within the ActionsModal.
- Created a zustand store for managing preferences state, including dev mode toggle functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccountHeader.tsx</strong><dd><code>Refactor CSS classes in AccountHeader component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/components/WalletSideKick/AccountHeader.tsx

- Adjusted CSS classes for better readability and maintainability.



</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/760/files#diff-434e16726f5ff844448f2fd5d61e39b297190bace9822f91383380c7b526f25b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountPreferencesModal.tsx</strong><dd><code>Add dev mode toggle and form handling in AccountPreferencesModal</code></dd></summary>
<hr>

explorer/src/components/WalletSideKick/AccountPreferencesModal.tsx

<li>Added dev mode toggle in account settings.<br> <li> Implemented form validation for dev mode settings.<br> <li> Added form submission handling for account settings.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/760/files#diff-50976ee70c91d00560c3bd7220a051c45b1ff49a4a38b7320d6d6d7218fe7fe2">+74/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountSummary.tsx</strong><dd><code>Display dev mode indicator and settings button in AccountSummary</code></dd></summary>
<hr>

explorer/src/components/WalletSideKick/AccountSummary.tsx

<li>Added dev mode indicator in account summary.<br> <li> Included settings button in account summary.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/760/files#diff-2b1b09b8bbb7b9a2c14b5b476eae9ade9924be98fa2d2a6df44c6f5a798fb5cc">+17/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ActionsModal.tsx</strong><dd><code>Add nonce field and validation for dev mode in ActionsModal</code></dd></summary>
<hr>

explorer/src/components/WalletSideKick/ActionsModal.tsx

<li>Added nonce field for dev mode in various forms.<br> <li> Implemented form validation for nonce field.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/760/files#diff-07aae665e5d24aa2a97f9a487e9bf8c95ca428178cc1f7e5af927f4c01658763">+116/-8</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>wallet.ts</strong><dd><code>Add Settings enum value in AccountPreferenceSection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/constants/wallet.ts

- Added new enum value for account settings.



</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/760/files#diff-48c4b480224ad5631b897c6cc99ab7e24c58cc936a9722b10936e50c963e50fa">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>preferences.ts</strong><dd><code>Create zustand store for preferences state management</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

explorer/src/states/preferences.ts

<li>Created zustand store for managing preferences state.<br> <li> Implemented dev mode toggle functionality.<br>


</details>


  </td>
  <td><a href="https://github.com/subspace/astral/pull/760/files#diff-9d0b4718f3645a202afcf45251632270ed146c02533bf5e866ac08773489907d">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

