### PR TITLE
Update Talisman role qualification criteria

### DIFF
--- a/explorer/gql/graphql.tsx
+++ b/explorer/gql/graphql.tsx
@@ -32072,7 +32072,7 @@ export const CheckRoleDocument = gql`
     id
   }
   isTalismanFarmer: consensus_rewards(
-    where: {_or: [{reward_type: {_eq: "rewards.VoteReward"}}, {reward_type: {_eq: "rewards.BlockReward"}}], account_id: {_eq: $subspaceAccount}, _and: [{timestamp: {_gte: "2025-05-07T00:00:00.000"}}, {timestamp: {_lte: "2025-06-04T00:00:00.000"}}]}
+    where: {_or: [{reward_type: {_eq: "rewards.VoteReward"}}, {reward_type: {_eq: "rewards.BlockReward"}}], account_id: {_eq: $subspaceAccount}, _and: [{timestamp: {_gte: "2025-05-07T00:00:00.000"}}, {timestamp: {_lte: "2025-06-05T00:00:00.000"}}]}
     limit: 1
   ) {
     account {

--- a/explorer/src/components/WalletSideKick/query.gql
+++ b/explorer/src/components/WalletSideKick/query.gql
@@ -76,7 +76,7 @@ query CheckRole($subspaceAccount: String!) {
       account_id: { _eq: $subspaceAccount }
       _and: [
         { timestamp: { _gte: "2025-05-07T00:00:00.000" } }
-        { timestamp: { _lte: "2025-06-04T00:00:00.000" } }
+        { timestamp: { _lte: "2025-06-05T00:00:00.000" } }
       ]
     }
     limit: 1


### PR DESCRIPTION
Update role qualification query to include the 4th of June in the Cosmic Cultivators contest. Effectively making 2025-06-04 the last day to qualify rather than 2025-06-03.